### PR TITLE
FixBuild : Add AV_ prefixing based on "lavc: add AV prefix to codec ids." libav …

### DIFF
--- a/veejay-current/veejay-server/libel/avhelper.c
+++ b/veejay-current/veejay-server/libel/avhelper.c
@@ -39,6 +39,46 @@ static struct
         int  id;
 } _supported_codecs[] = 
 {
+#if LIBAVCODEC_BUILD > 5425
+	{ "vj20", CODEC_ID_YUV420F	},
+	{ "vj22", CODEC_ID_YUV422F	},
+    { "mjpg" ,AV_CODEC_ID_MJPEG 	},
+	{ "mjpb", AV_CODEC_ID_MJPEGB	},
+    { "i420", CODEC_ID_YUV420	},
+    { "i422", CODEC_ID_YUV422	},
+	{ "dmb1", AV_CODEC_ID_MJPEG	},
+	{ "jpeg", AV_CODEC_ID_MJPEG	},
+	{ "mjpa", AV_CODEC_ID_MJPEG	},
+	{ "mjpb", AV_CODEC_ID_MJPEG	},
+	{ "jfif", AV_CODEC_ID_MJPEG	},
+	{ "jfif", AV_CODEC_ID_MJPEG	},
+	{ "png", AV_CODEC_ID_PNG		},
+	{ "mpng", AV_CODEC_ID_PNG		},
+#if LIBAVCODEC_BUILD > 4680
+	{ "sp5x", AV_CODEC_ID_SP5X		},
+#endif
+	{ "jpgl", AV_CODEC_ID_MJPEG 	},
+	{ "jpgl", AV_CODEC_ID_MJPEG	},
+	{ "dvsd", AV_CODEC_ID_DVVIDEO	},
+	{ "dvcp", AV_CODEC_ID_DVVIDEO	},
+	{ "dv",	AV_CODEC_ID_DVVIDEO	},
+	{ "dvhd", AV_CODEC_ID_DVVIDEO	},
+	{ "dvp", AV_CODEC_ID_DVVIDEO	},
+	{ "yuv", CODEC_ID_YUV420	},
+	{ "iyuv", CODEC_ID_YUV420	},
+	{ "i420", CODEC_ID_YUV420	},
+	{ "yv16", CODEC_ID_YUV422	},
+	{ "yv12", CODEC_ID_YUV420	},
+	{ "mlzo", CODEC_ID_YUVLZO	},
+	{ "hfyu", AV_CODEC_ID_HUFFYUV	},
+	{ "cyuv", AV_CODEC_ID_CYUV		},
+	{ "svq1", AV_CODEC_ID_SVQ1		},
+	{ "svq3", AV_CODEC_ID_SVQ3		},
+	{ "rpza", AV_CODEC_ID_RPZA		},
+	{ "y42b", CODEC_ID_YUV422F  },
+	{ "pict", 0xffff			},
+	{ NULL  , 0,				},
+#else
 	{ "vj20", CODEC_ID_YUV420F	},
 	{ "vj22", CODEC_ID_YUV422F	},
     { "mjpg" ,CODEC_ID_MJPEG 	},
@@ -54,7 +94,7 @@ static struct
 	{ "png", CODEC_ID_PNG		},
 	{ "mpng", CODEC_ID_PNG		},
 #if LIBAVCODEC_BUILD > 4680
-	{ "sp5x", CODEC_ID_SP5X		}, 
+	{ "sp5x", CODEC_ID_SP5X		},
 #endif
 	{ "jpgl", CODEC_ID_MJPEG 	},
 	{ "jpgl", CODEC_ID_MJPEG	},
@@ -68,7 +108,7 @@ static struct
 	{ "i420", CODEC_ID_YUV420	},
 	{ "yv16", CODEC_ID_YUV422	},
 	{ "yv12", CODEC_ID_YUV420	},
-	{ "mlzo", CODEC_ID_YUVLZO	}, 
+	{ "mlzo", CODEC_ID_YUVLZO	},
 	{ "hfyu", CODEC_ID_HUFFYUV	},
 	{ "cyuv", CODEC_ID_CYUV		},
 	{ "svq1", CODEC_ID_SVQ1		},
@@ -77,6 +117,8 @@ static struct
 	{ "y42b", CODEC_ID_YUV422F  },
 	{ "pict", 0xffff			},
 	{ NULL  , 0,				},
+#endif // #if LIBAVCODEC_BUILD > 5425
+
 };
 
 
@@ -214,11 +256,18 @@ void	*avhelper_get_decoder( const char *filename, int dst_pixfmt, int dst_width,
 	{
 		if( !x->avformat_ctx->streams[i]->codec )
 			continue;
-
+#if LIBAVCODEC_BUILD > 5425
+		if( x->avformat_ctx->streams[i]->codec->codec_type > AV_CODEC_ID_FIRST_SUBTITLE ) 
+#else
 		if( x->avformat_ctx->streams[i]->codec->codec_type > CODEC_ID_FIRST_SUBTITLE ) 
+#endif
 			continue;
-		
+
+#if LIBAVCODEC_BUILD > 5425
+		if( x->avformat_ctx->streams[i]->codec->codec_type < AV_CODEC_ID_FIRST_AUDIO )
+#else
 		if( x->avformat_ctx->streams[i]->codec->codec_type < CODEC_ID_FIRST_AUDIO )
+#endif
 		{
 				int sup_codec = 0;
 				for( j = 0; _supported_codecs[j].name != NULL; j ++ ) {


### PR DESCRIPTION
…commit

[lavc: add AV prefix to codec ids](https://git.libav.org/?p=libav.git;a=commitdiff;h=104e10fb426f903ba9157fdbfe30292d0e4c3d72)

Fix build on regular libav from ubuntu 14.10


