### PR TITLE
sayVIMS : manpage fixes + add -? option  + fix interactive mode

### DIFF
--- a/veejay-current/veejay-server/man/veejay.1
+++ b/veejay-current/veejay-server/man/veejay.1
@@ -124,6 +124,9 @@ Quit at end of video
 .B \-n/--no-color
 Dont use colored text.
 .TP
+.B \-u/--dump-events
+Dump veejay's documentation to stdout
+.TP
 .B \-m/--memory [0-100]
 Frame cache size in percentage of total system RAM 
 .TP

--- a/veejay-current/veejay-utils/man/sayVIMS.1
+++ b/veejay-current/veejay-utils/man/sayVIMS.1
@@ -23,7 +23,7 @@ Use a filename instead of strings on the commandline
 Multicast address to send to
 .TP
 .B \-i
-Start in interactive mode (use ? to get help)
+Start in interactive mode (use -? to get help, exit interactive mode typing 'quit')
 .TP
 .B \-c
 Start with colored text (geek feature)

--- a/veejay-current/veejay-utils/man/sayVIMS.1
+++ b/veejay-current/veejay-utils/man/sayVIMS.1
@@ -30,10 +30,10 @@ Start with colored text (geek feature)
 
 .SH USEFULL EXAMPLES
 .TP
-.B sayVIMS -h localhost -p 3490 "255:;"
-Start sayVIMS and connect to veejay (and tell veejay to quit)
+.B sayVIMS -h localhost -p 3490 \*(lq017:;\*(lq
+Start sayVIMS and connect to veejay (and tell veejay go to sample starting position)
 .TP
-.B sayVIMS -g 224.0.0.50 -p 5000 "255:;"
+.B sayVIMS -g 224.0.0.50 -p 5000 \*(lq017:;\*(lq
 Ditto, for multicast.
 .TP
 .SH Message Format
@@ -43,7 +43,7 @@ A message is described as
 For example:
 .B 099:1 0;
 .TP
-The selector is a 3 digit number identifying some atomic function in veejay. The colon is used to indicate the start of the list of arguments. The semicolon denotes the end of message.
+The selector is a 3 digit number identifying some atomic function in veejay ("veejay -u|less" to list all events). The colon is used to indicate the start of the list of arguments. The semicolon denotes the end of message.
 .TP
 .SH Passing arguments
 Each of veejay's functions except an ordered argument list ; depending on the 

--- a/veejay-current/veejay-utils/src/sayVIMS.c
+++ b/veejay-current/veejay-utils/src/sayVIMS.c
@@ -42,6 +42,7 @@ static int single_msg = 0;
 static int dump = 0;
 static int verbose = 0;
 static int base64_encode = 0;
+static int help = 0;
 
 #ifdef BASE64_AVUTIL
 #include <libavutil/base64.h>
@@ -279,6 +280,7 @@ static void Usage(char *progname)
 	fprintf(stderr, " -d\t\tDump status to stdout\n");
 	fprintf(stderr, " -b\t\tBase64 encode binary data\n");
 	fprintf(stderr, " -v\t\tVerbose\n");
+	fprintf(stderr, " -?\t\tPrint this help\n");
 	fprintf(stderr, "Exit interactive mode by typing 'quit'\n");
 	fprintf(stderr, "Messages to send to veejay must be wrapped in quotes\n");
 	fprintf(stderr, "You can send multiple messages by seperating them with a whitespace\n");
@@ -330,6 +332,9 @@ static int set_option(const char *name, char *value)
 		fprintf(stderr, "compiled without base64 support\n");
 		err++;
 #endif
+	}else if(strcmp(name,"?") == 0)
+	{
+		help = 1;
 	}
 	else err++;
 
@@ -368,13 +373,13 @@ int main(int argc, char *argv[])
 	veejay_set_debug_level(verbose);
 
 	// parse commandline parameters
-	while( ( n = getopt(argc,argv, "h:g:p:midbv")) != EOF)
+	while( ( n = getopt(argc,argv, "h:g:p:midbv?")) != EOF)
 	{
 		sprintf(option,"%c",n);
 		err += set_option( option,optarg);
 	}
 
-	if( err  || optind > argc)
+	if(help || err  || optind > argc)
 	{
 		Usage( argv[0] );
 		return -1;

--- a/veejay-current/veejay-utils/src/sayVIMS.c
+++ b/veejay-current/veejay-utils/src/sayVIMS.c
@@ -82,7 +82,10 @@ static struct {
 };
 static void vjsend( vj_client *c, int cmd, char *buf )
 {
-	buf[ strcspn(buf,"\n\r") ] = '\0';
+	size_t index = strcspn(buf,"\n\r");
+	if (index) {
+		buf[ index ] = '\0';
+	}
 	vj_client_send( c,cmd, buf);
 }
 
@@ -213,8 +216,7 @@ static int processLine(FILE *infile, FILE *outfile, char *tmp, char *buffer, int
 		} else {
 			int vims_id = 0;
 			int mustRead = vimsMustReadReply( tmp, &vims_id );
-
-			vj_client_send( sayvims, V_CMD, tmp );
+			vjsend( sayvims, V_CMD, tmp );
 
 			if( mustRead ) {
 				if( vims_id == VIMS_GET_SHM ) {


### PR DESCRIPTION
* change 255 example code by 017
* fix double quotes in bold text with \*(lq  : http://linux.die.net/man/7/man
* veejay -u|less
* veejay manpage : add missing arg -u
* sayVIMS : add -? has command line option 
* fix interactive mode (doesn't fix the #63 !)