### PR TITLE
Reloaded - FX panel changes in size : Fixed

### DIFF
--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -1668,6 +1668,7 @@
                             </child>
                             <child>
                               <widget class="GtkHBox" id="frame_fxtree2">
+                                <property name="height_request">120</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -1685,7 +1686,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p0">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -1809,7 +1813,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p1">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -1932,7 +1939,11 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p2">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
+
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2055,7 +2066,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p3">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2178,7 +2192,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p4">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2301,7 +2318,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p5">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2425,7 +2445,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p6">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2548,7 +2571,10 @@
                                             <property name="can_focus">False</property>
                                             <child>
                                               <widget class="GtkLabel" id="label_p7">
+                                                <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="yalign">0.95</property>
                                                 <property name="angle">90</property>
                                               </widget>
                                               <packing>
@@ -2676,7 +2702,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p8">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -2812,7 +2841,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p9">
+                                                   <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -2948,7 +2980,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p10">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -3084,7 +3119,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p11">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -3220,7 +3258,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p12">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -3356,7 +3397,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p13">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -3492,7 +3536,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p14">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>
@@ -3628,7 +3675,10 @@
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <widget class="GtkLabel" id="label_p15">
+                                                    <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="yalign">0.95</property>
                                                     <property name="angle">90</property>
                                                   </widget>
                                                   <packing>

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -6674,9 +6674,9 @@ static void process_reload_hints(int *history, int pm)
 
 				gchar *tt1 = _utf8str(_effect_get_param_description(entry_tokens[ENTRY_FXID],i));
 				set_tooltip( slider_names_[i].text, tt1 );
-		//		gtk_label_set_text(GTK_LABEL(glade_xml_get_widget_(info->main_window,
-		//		                                                   param_names_[i].text)),
-		//		                   tt1);
+				gtk_label_set_text(GTK_LABEL(glade_xml_get_widget_(info->main_window,
+				                                                   param_names_[i].text)),
+				                   tt1);
 
 				gint min,max,value;
 				value = entry_tokens[ENTRY_PARAMSET + i];
@@ -6700,9 +6700,9 @@ static void process_reload_hints(int *history, int pm)
 			disable_widget( param_kfs_[i].text );
 			set_tooltip( param_kfs_[i].text, NULL );
 			set_tooltip( slider_names_[i].text, NULL );
-		//	gtk_label_set_text(GTK_LABEL (glade_xml_get_widget_(info->main_window,
-		//	                                                    param_names_[i].text)),
-		//	                   NULL);
+			gtk_label_set_text(GTK_LABEL (glade_xml_get_widget_(info->main_window,
+			                                                    param_names_[i].text)),
+			                   NULL);
 			update_slider_range( slider_names_[i].text, min,max, value, 0 );
 		}
 		GtkTreeModel *model = gtk_tree_view_get_model( GTK_TREE_VIEW(glade_xml_get_widget_(


### PR DESCRIPTION
#98

* Fx panel fixed size at 120
* Label visible=true
* Labels yalign 0.95 (0.5% from bottom)
* Update label on "process_reload_hints"