### PR TITLE
Reloaded (various) fixes

### DIFF
--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -1698,6 +1698,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <widget class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -4766,7 +4772,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <widget class="GtkHBox" id="fxanimcontrols">
+                              <widget class="GtkHBox" id="hbox49">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -4780,137 +4786,148 @@
                                   </widget>
                                   <packing>
                                     <property name="expand">False</property>
-                                    <property name="fill">False</property>
+                                    <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkLabel" id="label686">
+                                  <widget class="GtkHBox" id="fxanimcontrols">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">&lt;b&gt;current control:&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
-                                  </widget>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <widget class="GtkLabel" id="curve_parameter">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">P0</property>
-                                  </widget>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <widget class="GtkToggleButton" id="curve_toggleentry_param">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip" translatable="yes">Toggle keyframe animation for this parameter</property>
-                                    <signal name="toggled" handler="on_curve_toggleentry_param_toggled" />
                                     <child>
-                                      <widget class="GtkImage" id="image2146">
+                                      <widget class="GtkLabel" id="label686">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="pixbuf">icon_keyframe.png</property>
-                                      </widget>
-                                    </child>
-                                  </widget>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <widget class="GtkHBox" id="hbox850">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="homogeneous">True</property>
-                                    <child>
-                                      <widget class="GtkButton" id="curve_buttonstore">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip" translatable="yes">Apply this keyframe</property>
-                                        <signal name="clicked" handler="on_curve_buttonstore_clicked" />
-                                        <child>
-                                          <widget class="GtkImage" id="image2521">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="pixbuf">icon_apply.png</property>
-                                          </widget>
-                                        </child>
+                                        <property name="label" translatable="yes">&lt;b&gt;current control:&lt;/b&gt;</property>
+                                        <property name="use_markup">True</property>
                                       </widget>
                                       <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <widget class="GtkToggleButton" id="curve_togglerun">
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip" translatable="yes">Start keyframing</property>
-                                        <signal name="toggled" handler="on_curve_togglerun_toggled" />
-                                        <child>
-                                          <widget class="GtkImage" id="image530">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="pixbuf">button_play.png</property>
-                                          </widget>
-                                        </child>
+                                      <widget class="GtkLabel" id="curve_parameter">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">P0</property>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>
-                                        <property name="fill">True</property>
+                                        <property name="fill">False</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <widget class="GtkButton" id="curve_buttonclear">
+                                      <widget class="GtkToggleButton" id="curve_toggleentry_param">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="tooltip" translatable="yes">Reset</property>
-                                        <signal name="clicked" handler="on_curve_buttonclear_clicked" />
+                                        <property name="tooltip" translatable="yes">Toggle keyframe animation for this parameter</property>
+                                        <signal name="toggled" handler="on_curve_toggleentry_param_toggled" />
                                         <child>
-                                          <widget class="GtkImage" id="image532">
+                                          <widget class="GtkImage" id="image2146">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="pixbuf">icon_clearall.png</property>
+                                            <property name="pixbuf">icon_keyframe.png</property>
                                           </widget>
                                         </child>
                                       </widget>
                                       <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <widget class="GtkButton" id="curve_clear_parameter">
+                                      <widget class="GtkHBox" id="hbox850">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip" translatable="yes">Clear selected parameter</property>
-                                        <signal name="clicked" handler="on_curve_clear_parameter_clicked" />
+                                        <property name="can_focus">False</property>
+                                        <property name="homogeneous">True</property>
                                         <child>
-                                          <widget class="GtkImage" id="image17">
+                                          <widget class="GtkButton" id="curve_buttonstore">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="pixbuf">icon_clear.png</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip" translatable="yes">Apply this keyframe</property>
+                                            <signal name="clicked" handler="on_curve_buttonstore_clicked" />
+                                            <child>
+                                              <widget class="GtkImage" id="image2521">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="pixbuf">icon_apply.png</property>
+                                              </widget>
+                                            </child>
                                           </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkToggleButton" id="curve_togglerun">
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip" translatable="yes">Start keyframing</property>
+                                            <signal name="toggled" handler="on_curve_togglerun_toggled" />
+                                            <child>
+                                              <widget class="GtkImage" id="image530">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="pixbuf">button_play.png</property>
+                                              </widget>
+                                            </child>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkButton" id="curve_buttonclear">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip" translatable="yes">Reset</property>
+                                            <signal name="clicked" handler="on_curve_buttonclear_clicked" />
+                                            <child>
+                                              <widget class="GtkImage" id="image532">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="pixbuf">icon_clearall.png</property>
+                                              </widget>
+                                            </child>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkButton" id="curve_clear_parameter">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip" translatable="yes">Clear selected parameter</property>
+                                            <signal name="clicked" handler="on_curve_clear_parameter_clicked" />
+                                            <child>
+                                              <widget class="GtkImage" id="image17">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="pixbuf">icon_clear.png</property>
+                                              </widget>
+                                            </child>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
                                         </child>
                                       </widget>
                                       <packing>
@@ -4923,7 +4940,7 @@
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
-                                    <property name="position">4</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </widget>
@@ -15818,6 +15835,12 @@ YUV (current)</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="n_columns">4</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                     <child>
                       <placeholder/>
                     </child>

--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -14787,7 +14787,7 @@ YUV (current)</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="tooltip" translatable="yes">Save Samplelist</property>
+                                    <property name="tooltip" translatable="yes">Save Samplelist (press [SHIFT] to Save as)</property>
                                     <signal name="button_press_event" handler="on_button_samplelist_qsave_clicked" />
                                     <child>
                                       <widget class="GtkAlignment" id="alignment55">

--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -1692,6 +1692,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <widget class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -4764,6 +4770,21 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
+                                  <widget class="GtkToggleButton" id="curve_panel_toggleentry">
+                                    <property name="label" translatable="yes">FX Anim</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="tooltip" translatable="yes">Toggle keyframing for this chain entry</property>
+                                    <signal name="toggled" handler="curve_panel_toggleentry_toggled" />
+                                  </widget>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <widget class="GtkLabel" id="label686">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -4773,7 +4794,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">0</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -4786,7 +4807,7 @@
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">False</property>
-                                    <property name="position">1</property>
+                                    <property name="position">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -4807,7 +4828,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">2</property>
+                                    <property name="position">3</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -4902,7 +4923,7 @@
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
-                                    <property name="position">3</property>
+                                    <property name="position">4</property>
                                   </packing>
                                 </child>
                               </widget>
@@ -5582,7 +5603,7 @@
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">True</property>
                                                 <property name="tooltip" translatable="yes">Clear all sequencer slots</property>
-                                                <signal name="clicked" handler="on_button_seq_clearall_clicked" swapped="no"/>
+                                                <signal name="clicked" handler="on_button_seq_clearall_clicked" />
                                                 <child>
                                                   <widget class="GtkHBox" id="hbox48">
                                                     <property name="visible">True</property>
@@ -13504,13 +13525,13 @@ YUV (current)</property>
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <widget class="GtkToggleButton" id="curve_toggleentry">
+                                                      <widget class="GtkToggleButton" id="curve_chain_toggleentry">
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
                                                         <property name="receives_default">True</property>
                                                         <property name="has_tooltip">True</property>
                                                         <property name="tooltip" translatable="yes">Toggle keyframing for this chain entry</property>
-                                                        <signal name="toggled" handler="curve_toggleentry_toggled" />
+                                                        <signal name="toggled" handler="curve_chain_toggleentry_toggled" />
                                                         <child>
                                                           <widget class="GtkImage" id="image50">
                                                             <property name="visible">True</property>
@@ -15797,6 +15818,12 @@ YUV (current)</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="n_columns">4</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                     <child>
                       <placeholder/>
                     </child>

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2740,7 +2740,7 @@ void	curve_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 		return;
 	}
 
-	int k = is_button_toggled( "curve_chain_toggleentry" );
+	int k = gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) );
 	int type = 0;
 	if(  is_button_toggled("curve_typespline")) {
 		type = 1;

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2761,9 +2761,19 @@ void	curve_chain_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	curve_toggleentry_toggled( widget, user_data);
 
 	GtkWidget *siamese = glade_xml_get_widget_( info->main_window, "curve_panel_toggleentry");
-	if(siamese) {
+	if(siamese)
+	{
+		guint signal_id=g_signal_lookup("toggled", GTK_TYPE_TOGGLE_BUTTON);
+		gulong handler_id=handler_id=g_signal_handler_find( (gpointer)siamese, G_SIGNAL_MATCH_ID, signal_id, 0, NULL, NULL, NULL );
+
+		if (handler_id)
+			g_signal_handler_block((gpointer)siamese, handler_id);
+
 		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(siamese),
 		                              gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) )) ;
+
+		if (handler_id)
+			g_signal_handler_unblock((gpointer)siamese, handler_id);
 	}
 }
 
@@ -2772,9 +2782,19 @@ void	curve_panel_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	curve_toggleentry_toggled( widget, user_data);
 
 	GtkWidget *siamese = glade_xml_get_widget_( info->main_window, "curve_chain_toggleentry");
-	if(siamese) {
+	if(siamese)
+	{
+		guint signal_id=g_signal_lookup("toggled", GTK_TYPE_TOGGLE_BUTTON);
+		gulong handler_id=handler_id=g_signal_handler_find( (gpointer)siamese, G_SIGNAL_MATCH_ID, signal_id, 0, NULL, NULL, NULL );
+
+		if (handler_id)
+			g_signal_handler_block((gpointer)siamese, handler_id);
+
 		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(siamese),
 		                              gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) )) ;
+
+		if (handler_id)
+			g_signal_handler_unblock((gpointer)siamese, handler_id);
 	}
 }
 

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2734,25 +2734,37 @@ void	curve_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	if(info->status_lock)
 		return;
 
-	int i = info->uc.selected_chain_entry;
-	if( i == -1 ) {
+	int selected_chain_entry = info->uc.selected_chain_entry;
+	if( selected_chain_entry == -1 ) {
 		vj_msg(VEEJAY_MSG_INFO,"No parameter selected for animation");
 		return;
 	}
 
-	int k = gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) );
-	int type = 0;
-	if(  is_button_toggled("curve_typespline")) {
-		type = 1;
+	int active = gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) );
+	int curve_type = 0;
+	if( is_button_toggled("curve_typespline")) {
+		curve_type = 1;
 	} else if ( is_button_toggled("curve_typefreehand")) {
-		type = 2;
+		curve_type = 2;
 	} else if (is_button_toggled("curve_typelinear")) {
-		type = 0;
+		curve_type = 0;
 	}
 
-	multi_vims( VIMS_SAMPLE_KF_STATUS, "%d %d %d", i, k,type );
+	multi_vims( VIMS_SAMPLE_KF_STATUS, "%d %d %d",
+	           selected_chain_entry, active, curve_type );
 
-	info->uc.reload_hint[HINT_ENTRY] = 1;
+	//update anim mode
+	GtkTreeView *view = GTK_TREE_VIEW(glade_xml_get_widget_(info->main_window, "tree_chain"));
+	GtkTreeModel *model = gtk_tree_view_get_model( view );
+	GtkTreeIter iter;
+
+	GtkTreePath *path = gtk_tree_path_new_from_indices(selected_chain_entry, -1);
+	if(gtk_tree_model_get_iter(model, &iter, path))
+	{
+		GdkPixbuf *kf_toggle = update_pixmap_kf( active );
+		gtk_list_store_set (GTK_LIST_STORE( model ), &iter, FXC_KF, kf_toggle, -1);
+	}
+	gtk_tree_path_free(path);
 }
 
 

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2798,7 +2798,7 @@ void	curve_panel_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	}
 }
 
-void	on_kf_none_toggled( GtkWidget widget, gpointer user_data)
+void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	info->uc.selected_parameter_id = -1;
 	
@@ -2811,89 +2811,89 @@ void	on_kf_none_toggled( GtkWidget widget, gpointer user_data)
 	vj_kf_reset();	
 }
 
-void	on_kf_p0_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p0_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if(is_button_toggled("kf_p0"))
 		KF_CHANGED( 0 );
 }
-void	on_kf_p1_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p1_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p1")) 
 		KF_CHANGED( 1 );
 }
-void	on_kf_p2_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p2_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p2"))
 		KF_CHANGED( 2 );
 }
-void	on_kf_p3_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p3_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p3"))
 		KF_CHANGED( 3 );
 }
-void	on_kf_p4_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p4_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p4"))
 		KF_CHANGED( 4 );
 }
-void	on_kf_p5_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p5_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p5"))
 		KF_CHANGED( 5 );
 }
-void	on_kf_p6_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p6_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p6"))
 		KF_CHANGED( 6 );
 }
-void	on_kf_p7_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p7_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p7"))
 		KF_CHANGED( 7 );
 }
-void	on_kf_p8_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p8_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p8"))
 		KF_CHANGED( 8 );
 }
-void	on_kf_p9_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p9_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p9"))
 		KF_CHANGED( 9 );
 }
-void	on_kf_p10_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p10_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p10"))
 		KF_CHANGED( 10 );
 }
 
-void	on_kf_p11_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p11_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p11"))
 		KF_CHANGED( 11 );
 }
 
-void	on_kf_p12_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p12_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p12"))
 		KF_CHANGED( 12 );
 }
 
 
-void	on_kf_p13_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p13_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p13"))
 		KF_CHANGED( 13 );
 }
 
 
-void	on_kf_p14_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p14_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p14"))
 		KF_CHANGED( 14 );
 }
 
-void	on_kf_p15_toggled( GtkWidget *widget, gpointer user_data)
+void	on_kf_p15_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p15"))
 		KF_CHANGED( 15 );

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -16,10 +16,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
+
 #include <ctype.h>
 #include <veejay/vj-msg.h>
 #include <gtktimeselection.h>
 #include <veejay/vims.h>
+#include "callback.h"
+
 static int config_file_status = 0;
 static gchar *config_file = NULL;
 static int srt_locked_ = 0;
@@ -606,44 +609,6 @@ void	on_button_fx_del_clicked(GtkWidget *w, gpointer user_data)
 		info->uc.selected_chain_entry);
 }
 
-#define	slider_changed( arg_num, value ) \
-{\
-if(!info->status_lock && !info->parameter_lock)\
-{\
-info->parameter_lock = 1;\
-multi_vims( VIMS_CHAIN_ENTRY_SET_ARG_VAL, "%d %d %d %d", 0, info->uc.selected_chain_entry,arg_num, value );\
-vj_midi_learning_vims_fx( info->midi, arg_num, VIMS_CHAIN_ENTRY_SET_ARG_VAL, 0,info->uc.selected_chain_entry, arg_num,1 );\
-if(info->uc.selected_rgbkey) update_rgbkey_from_slider(); \
-int *entry_tokens = &(info->uc.entry_tokens[0]);\
-update_label_str( "value_friendlyname", _effect_get_hint( entry_tokens[ENTRY_FXID], arg_num, value ));\
-info->parameter_lock = 0;\
-}\
-}
-
-#define	param_changed( arg_num, fraction, name ) \
-{\
-if(!info->status_lock && !info->parameter_lock)\
-{\
-info->parameter_lock = 1;\
-multi_vims( VIMS_CHAIN_ENTRY_SET_ARG_VAL, "%d %d %d %d", 0, info->uc.selected_chain_entry,arg_num, (get_slider_val(name) + fraction) );\
-update_slider_value( name, (get_slider_val(name) + fraction), 0 );\
-vj_midi_learning_vims_fx( info->midi, arg_num, VIMS_CHAIN_ENTRY_SET_ARG_VAL, 0, info->uc.selected_chain_entry,arg_num,2 );\
-if(info->uc.selected_rgbkey) update_rgbkey_from_slider(); \
-int *entry_tokens = &(info->uc.entry_tokens[0]);\
-update_label_str( "value_friendlyname", _effect_get_hint( entry_tokens[ENTRY_FXID], arg_num, get_slider_val(name) ));\
-info->parameter_lock = 0;\
-}\
-}
-
-
-#define kf_changed( arg_num ) \
-{\
-enable_widget("fxanimcontrols");\
-if(arg_num != info->uc.selected_parameter_id)\
-{\
-vj_kf_select_parameter(arg_num);\
-}\
-}
 static void gen_changed( int num, int value )
 {
 	int i;
@@ -709,206 +674,206 @@ static void genv_changed( int num, int value, const char *selected )
 
 void	on_slider_p0_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 0, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 0, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p1_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 1, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 1, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p2_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 2, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 2, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p3_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 3, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 3, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p4_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 4, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 4, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p5_value_changed(GtkWidget *w, gpointer user_data)
 {
-		slider_changed( 5, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+		SLIDER_CHANGED( 5, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p6_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 6, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 6, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p7_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 7, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 7, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p8_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 8, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 8, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p9_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 9, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 9, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_slider_p10_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 10, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 10, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p11_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 11, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 11, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p12_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 12, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 12, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p13_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 13, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 13, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p14_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 14, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 14, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 void	on_slider_p15_value_changed(GtkWidget *w, gpointer user_data)
 {
-	slider_changed( 15, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
+	SLIDER_CHANGED( 15, (gint)GTK_ADJUSTMENT(GTK_RANGE(w)->adjustment)->value );
 }
 
 void	on_inc_p0_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 0, 1 , "slider_p0" );
+	PARAM_CHANGED( 0, 1 , "slider_p0" );
 }
 void	on_dec_p0_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 0, -1, "slider_p0");
+	PARAM_CHANGED( 0, -1, "slider_p0");
 }
 void	on_inc_p1_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 1, 1 , "slider_p1" );
+	PARAM_CHANGED( 1, 1 , "slider_p1" );
 }
 void	on_dec_p1_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 1, -1, "slider_p1");
+	PARAM_CHANGED( 1, -1, "slider_p1");
 
 }
 void	on_inc_p2_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 2, 1 , "slider_p2" );
+	PARAM_CHANGED( 2, 1 , "slider_p2" );
 }
 void	on_dec_p2_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 2, -1, "slider_p2");
+	PARAM_CHANGED( 2, -1, "slider_p2");
 }
 void	on_inc_p3_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 3, 1 , "slider_p3" );
+	PARAM_CHANGED( 3, 1 , "slider_p3" );
 }
 	void	on_dec_p3_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 3, -1, "slider_p3");
+	PARAM_CHANGED( 3, -1, "slider_p3");
 }
 void	on_inc_p4_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(4, 1 , "slider_p4" );
+	PARAM_CHANGED(4, 1 , "slider_p4" );
 }
 void	on_dec_p4_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 4, -1, "slider_p4");
+	PARAM_CHANGED( 4, -1, "slider_p4");
 }
 
 void	on_inc_p5_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(5, 1 , "slider_p5" );
+	PARAM_CHANGED(5, 1 , "slider_p5" );
 }
 void	on_dec_p5_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 5, -1, "slider_p5");
+	PARAM_CHANGED( 5, -1, "slider_p5");
 }
 
 void	on_inc_p6_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(6, 1 , "slider_p6" );
+	PARAM_CHANGED(6, 1 , "slider_p6" );
 }
 void	on_dec_p6_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 6, -1, "slider_p6");
+	PARAM_CHANGED( 6, -1, "slider_p6");
 }
 
 void	on_inc_p7_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(7, 1 , "slider_p7" );
+	PARAM_CHANGED(7, 1 , "slider_p7" );
 }
 void	on_dec_p7_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 7, -1, "slider_p7");
+	PARAM_CHANGED( 7, -1, "slider_p7");
 }
 void	on_inc_p8_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(8, 1 , "slider_p8" );
+	PARAM_CHANGED(8, 1 , "slider_p8" );
 }
 void	on_dec_p8_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 8, -1, "slider_p8");
+	PARAM_CHANGED( 8, -1, "slider_p8");
 }
 void	on_inc_p9_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(9, 1 , "slider_p9" );
+	PARAM_CHANGED(9, 1 , "slider_p9" );
 }
 void	on_dec_p9_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 9, -1, "slider_p9");
+	PARAM_CHANGED( 9, -1, "slider_p9");
 }
 void	on_inc_p10_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(10, 1 , "slider_p10" );
+	PARAM_CHANGED(10, 1 , "slider_p10" );
 }
 void	on_dec_p10_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 10, -1, "slider_p10");
+	PARAM_CHANGED( 10, -1, "slider_p10");
 }
 void	on_inc_p11_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(11, 1 , "slider_p11" );
+	PARAM_CHANGED(11, 1 , "slider_p11" );
 }
 void	on_dec_p11_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 11, -1, "slider_p11");
+	PARAM_CHANGED( 11, -1, "slider_p11");
 }
 void	on_inc_p12_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(12, 1 , "slider_p12" );
+	PARAM_CHANGED(12, 1 , "slider_p12" );
 }
 void	on_dec_p12_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 12, -1, "slider_p12");
+	PARAM_CHANGED( 12, -1, "slider_p12");
 }
 void	on_inc_p13_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(13, 1 , "slider_p13" );
+	PARAM_CHANGED(13, 1 , "slider_p13" );
 }
 void	on_dec_p13_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 13, -1, "slider_p13");
+	PARAM_CHANGED( 13, -1, "slider_p13");
 }
 void	on_inc_p14_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(14, 1 , "slider_p14" );
+	PARAM_CHANGED(14, 1 , "slider_p14" );
 }
 void	on_dec_p14_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 14, -1, "slider_p14");
+	PARAM_CHANGED( 14, -1, "slider_p14");
 }
 void	on_inc_p15_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed(15, 1 , "slider_p15" );
+	PARAM_CHANGED(15, 1 , "slider_p15" );
 }
 void	on_dec_p15_clicked(GtkWidget *w, gpointer user_data)
 {
-	param_changed( 15, -1, "slider_p15");
+	PARAM_CHANGED( 15, -1, "slider_p15");
 }
 
 void	slider_g0_value_changed(GtkWidget *w, gpointer user_data)
@@ -2804,89 +2769,89 @@ void	on_kf_none_toggled( GtkWidget widget, gpointer user_data)
 void	on_kf_p0_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if(is_button_toggled("kf_p0"))
-		kf_changed( 0 );
+		KF_CHANGED( 0 );
 }
 void	on_kf_p1_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p1")) 
-		kf_changed( 1 );
+		KF_CHANGED( 1 );
 }
 void	on_kf_p2_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p2"))
-		kf_changed( 2 );
+		KF_CHANGED( 2 );
 }
 void	on_kf_p3_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p3"))
-		kf_changed( 3 );
+		KF_CHANGED( 3 );
 }
 void	on_kf_p4_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p4"))
-		kf_changed( 4 );
+		KF_CHANGED( 4 );
 }
 void	on_kf_p5_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p5"))
-		kf_changed( 5 );
+		KF_CHANGED( 5 );
 }
 void	on_kf_p6_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p6"))
-		kf_changed( 6 );
+		KF_CHANGED( 6 );
 }
 void	on_kf_p7_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p7"))
-		kf_changed( 7 );
+		KF_CHANGED( 7 );
 }
 void	on_kf_p8_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p8"))
-		kf_changed( 8 );
+		KF_CHANGED( 8 );
 }
 void	on_kf_p9_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p9"))
-		kf_changed( 9 );
+		KF_CHANGED( 9 );
 }
 void	on_kf_p10_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p10"))
-		kf_changed( 10 );
+		KF_CHANGED( 10 );
 }
 
 void	on_kf_p11_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p11"))
-		kf_changed( 11 );
+		KF_CHANGED( 11 );
 }
 
 void	on_kf_p12_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p12"))
-		kf_changed( 12 );
+		KF_CHANGED( 12 );
 }
 
 
 void	on_kf_p13_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p13"))
-		kf_changed( 13 );
+		KF_CHANGED( 13 );
 }
 
 
 void	on_kf_p14_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p14"))
-		kf_changed( 14 );
+		KF_CHANGED( 14 );
 }
 
 void	on_kf_p15_toggled( GtkWidget *widget, gpointer user_data)
 {
 	if( is_button_toggled("kf_p15"))
-		kf_changed( 15 );
+		KF_CHANGED( 15 );
 }
 
 void	on_button_videobook_clicked(GtkWidget *widget, gpointer user_data)

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2751,6 +2751,8 @@ void	curve_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	}
 
 	multi_vims( VIMS_SAMPLE_KF_STATUS, "%d %d %d", i, k,type );
+
+	info->uc.reload_hint[HINT_ENTRY] = 1;
 }
 
 void	on_kf_none_toggled( GtkWidget widget, gpointer user_data)

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2740,7 +2740,7 @@ void	curve_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 		return;
 	}
 
-	int k = is_button_toggled( "curve_toggleentry" );
+	int k = is_button_toggled( "curve_chain_toggleentry" );
 	int type = 0;
 	if(  is_button_toggled("curve_typespline")) {
 		type = 1;
@@ -2753,6 +2753,29 @@ void	curve_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	multi_vims( VIMS_SAMPLE_KF_STATUS, "%d %d %d", i, k,type );
 
 	info->uc.reload_hint[HINT_ENTRY] = 1;
+}
+
+
+void	curve_chain_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
+{
+	curve_toggleentry_toggled( widget, user_data);
+
+	GtkWidget *siamese = glade_xml_get_widget_( info->main_window, "curve_panel_toggleentry");
+	if(siamese) {
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(siamese),
+		                              gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) )) ;
+	}
+}
+
+void	curve_panel_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
+{
+	curve_toggleentry_toggled( widget, user_data);
+
+	GtkWidget *siamese = glade_xml_get_widget_( info->main_window, "curve_chain_toggleentry");
+	if(siamese) {
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(siamese),
+		                              gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) )) ;
+	}
 }
 
 void	on_kf_none_toggled( GtkWidget widget, gpointer user_data)

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2813,89 +2813,89 @@ void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
 
 void	on_kf_p0_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if(is_button_toggled("kf_p0"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 0 );
 }
 void	on_kf_p1_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p1")) 
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 1 );
 }
 void	on_kf_p2_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p2"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 2 );
 }
 void	on_kf_p3_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p3"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 3 );
 }
 void	on_kf_p4_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p4"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 4 );
 }
 void	on_kf_p5_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p5"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 5 );
 }
 void	on_kf_p6_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p6"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 6 );
 }
 void	on_kf_p7_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p7"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 7 );
 }
 void	on_kf_p8_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p8"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 8 );
 }
 void	on_kf_p9_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p9"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 9 );
 }
 void	on_kf_p10_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p10"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 10 );
 }
 
 void	on_kf_p11_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p11"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 11 );
 }
 
 void	on_kf_p12_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p12"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 12 );
 }
 
 
 void	on_kf_p13_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p13"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 13 );
 }
 
 
 void	on_kf_p14_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p14"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 14 );
 }
 
 void	on_kf_p15_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	if( is_button_toggled("kf_p15"))
+	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 15 );
 }
 

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -2800,15 +2800,18 @@ void	curve_panel_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 
 void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
 {
-	info->uc.selected_parameter_id = -1;
-	
-	disable_widget( "fxanimcontrols" );
-	disable_widget( "curve" );
+	if(gtk_toggle_button_get_active( widget ))
+	{
+		info->uc.selected_parameter_id = -1;
 
-	if(info->status_lock)
-		return;
+		disable_widget( "fxanimcontrols" );
+		disable_widget( "curve" );
 
-	vj_kf_reset();	
+		if(info->status_lock)
+			return;
+
+		vj_kf_reset();
+	}
 }
 
 void	on_kf_p0_toggled( GtkToggleButton *widget, gpointer user_data)

--- a/veejay-current/veejay-client/src/callback.h
+++ b/veejay-current/veejay-client/src/callback.h
@@ -1,0 +1,79 @@
+/* gveejay - Linux VeeJay - GVeejay GTK+-2/Glade User Interface
+ *           (C) 2002-2015 Niels Elburg <nwelburg@gmail.com>
+ *           (C) 2016 Jérôme Blanchi
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef VJCALLBACK_H
+#define VJCALLBACK_H
+
+#define	SLIDER_CHANGED( arg_num, value ) \
+{\
+if(!info->status_lock && !info->parameter_lock)\
+{\
+info->parameter_lock = 1;\
+multi_vims( VIMS_CHAIN_ENTRY_SET_ARG_VAL, "%d %d %d %d", 0, info->uc.selected_chain_entry,arg_num, value );\
+vj_midi_learning_vims_fx( info->midi, arg_num, VIMS_CHAIN_ENTRY_SET_ARG_VAL, 0,info->uc.selected_chain_entry, arg_num,1 );\
+if(info->uc.selected_rgbkey) update_rgbkey_from_slider(); \
+int *entry_tokens = &(info->uc.entry_tokens[0]);\
+update_label_str( "value_friendlyname", _effect_get_hint( entry_tokens[ENTRY_FXID], arg_num, value ));\
+info->parameter_lock = 0;\
+}\
+}
+
+#define	PARAM_CHANGED( arg_num, fraction, name ) \
+{\
+if(!info->status_lock && !info->parameter_lock)\
+{\
+info->parameter_lock = 1;\
+multi_vims( VIMS_CHAIN_ENTRY_SET_ARG_VAL, "%d %d %d %d", 0, info->uc.selected_chain_entry,arg_num, (get_slider_val(name) + fraction) );\
+update_slider_value( name, (get_slider_val(name) + fraction), 0 );\
+vj_midi_learning_vims_fx( info->midi, arg_num, VIMS_CHAIN_ENTRY_SET_ARG_VAL, 0, info->uc.selected_chain_entry,arg_num,2 );\
+if(info->uc.selected_rgbkey) update_rgbkey_from_slider(); \
+int *entry_tokens = &(info->uc.entry_tokens[0]);\
+update_label_str( "value_friendlyname", _effect_get_hint( entry_tokens[ENTRY_FXID], arg_num, get_slider_val(name) ));\
+info->parameter_lock = 0;\
+}\
+}
+
+
+#define KF_CHANGED( arg_num ) \
+{\
+enable_widget("fxanimcontrols");\
+if(arg_num != info->uc.selected_parameter_id)\
+{\
+vj_kf_select_parameter(arg_num);\
+}\
+}
+
+/*int sample_calctime();*/
+void text_defaults();
+
+gboolean boxbg_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+gboolean boxfg_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+gboolean boxln_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+gboolean boxred_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+gboolean boxblue_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+gboolean boxgreen_expose_event ( GtkWidget *w, GdkEventExpose *event, gpointer data );
+
+
+void on_timeline_value_changed ( GtkWidget *widget, gpointer user_data );
+void on_timeline_in_point_changed ( GtkWidget *widget, gpointer user_data );
+void on_timeline_out_point_changed ( GtkWidget *widget, gpointer user_data );
+void on_timeline_bind_toggled( GtkWidget *widget, gpointer user_data );
+void on_timeline_cleared ( GtkWidget *widget, gpointer user_data );
+
+#endif

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -2494,6 +2494,7 @@ static void vj_kf_refresh()
 	int *entry_tokens = &(info->uc.entry_tokens[0]);
 	if( entry_tokens[ENTRY_FXID] > 0 ) {
 		enable_widget( "frame_fxtree3" );
+		update_curve_widget(glade_xml_get_widget_(info->main_window, "curve"));
 	}
 	else {
 		set_toggle_button( "curve_toggleentry_param", 0 );

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -7346,9 +7346,9 @@ gboolean slider_scroll_event( GtkWidget *widget, GdkEventScroll *ev, gpointer us
 {
 	gint i = GPOINTER_TO_INT(user_data);
 	if(ev->direction == GDK_SCROLL_UP ) {
-		param_changed( i, 1, slider_names_[i].text );
+		PARAM_CHANGED( i, 1, slider_names_[i].text );
 	} else if (ev->direction == GDK_SCROLL_DOWN ) {
-		param_changed( i, -1, slider_names_[i].text );
+		PARAM_CHANGED( i, -1, slider_names_[i].text );
 	}
 	return FALSE;
 }

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -7411,6 +7411,7 @@ void vj_gui_init(char *glade_file,
 	veejay_memset( gui->sample, 0, 2 );
 	veejay_memset( gui->selection, 0, 3 );
 	veejay_memset( &(gui->uc), 0, sizeof(veejay_user_ctrl_t));
+	gui->uc.selected_parameter_id = -1;
 	veejay_memset( gui->uc.entry_tokens,0, sizeof(int) * ENTRY_LAST);
 	gui->prev_mode = -1;
 	veejay_memset( &(gui->el), 0, sizeof(veejay_el_t));

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -4096,7 +4096,7 @@ static void load_effectchain_info()
 
 		strncpy( line, fxtext + offset, VIMS_CHAIN_LIST_ENTRY_LENGHT );
 		sscanf( line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
-		       &arr[0],&arr[1],&arr[2],&arr[3],&arr[4],&arr[5],&arr[6]); // FIXME How to use of VIMS_CHAIN_LIST_ENTRY_VALUES ?
+		       &arr[0],&arr[1],&arr[2],&arr[3],&arr[4],&arr[5],&arr[6], &arr[7]); // FIXME How to use of VIMS_CHAIN_LIST_ENTRY_VALUES ?
 
 		char *name = _effect_get_description( arr[1] );
 		snprintf(toggle,sizeof(toggle),"%s",arr[3] == 1 ? "on" : "off" );
@@ -4125,7 +4125,7 @@ static void load_effectchain_info()
 
 			gtk_list_store_append( store, &iter );
 			GdkPixbuf *toggle = update_pixmap_entry( arr[3] );
-			GdkPixbuf *kf_togglepf = update_pixmap_kf( info->uc.entry_tokens[ENTRY_KF_STATUS] );
+			GdkPixbuf *kf_togglepf = update_pixmap_kf( arr[7] );
 			gtk_list_store_set( store, &iter,
 			                   FXC_ID, arr[0],
 			                   FXC_FXID, utf8_name,

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -674,7 +674,7 @@ void free_samplebank(void);
 void reset_samplebank(void);
 int verify_bank_capacity(int *bank_page_, int *slot_, int sample_id, int sample_type );
 static void widget_get_rect_in_screen (GtkWidget *widget, GdkRectangle *r);
-static void update_curve_widget(const char *name);
+static void update_curve_widget( GtkWidget *curve );
 /* not used */ /* static void update_curve_accessibility(const char *name); */
 static void reset_tree(const char *name);
 static void reload_srt();
@@ -2518,14 +2518,14 @@ static void vj_kf_select_parameter(int num)
 	update_label_str( "curve_parameter", name );
 	g_free(name);
 
-	reset_curve( glade_xml_get_widget_(info->main_window, "curve"));
+	GtkWidget *curve = glade_xml_get_widget_(info->main_window, "curve");
+	reset_curve( curve );
 
-	update_curve_widget("curve");
+	update_curve_widget( curve );
 }
 
-static void update_curve_widget(const char *name)
+static void update_curve_widget(GtkWidget *curve)
 {
-	GtkWidget *curve = glade_xml_get_widget_( info->main_window,name);
 	sample_slot_t *s = info->selected_slot;
 	if(!s ) 	return;
 	int i = info->uc.selected_chain_entry; /* chain entry */

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -4070,6 +4070,7 @@ static void load_effectchain_info()
 	GtkTreeModel *model = gtk_tree_view_get_model( GTK_TREE_VIEW(tree ));
 	store = GTK_LIST_STORE(model);
 
+	// no fx, clean list and return
 	if(fxlen <= 0 )
 	{
 		int i;
@@ -4100,6 +4101,7 @@ static void load_effectchain_info()
 		char *name = _effect_get_description( arr[1] );
 		snprintf(toggle,sizeof(toggle),"%s",arr[3] == 1 ? "on" : "off" );
 
+		// clean list entries until next
 		while( last_index < arr[0] )
 		{
 			gtk_list_store_append( store, &iter );
@@ -4107,6 +4109,7 @@ static void load_effectchain_info()
 			last_index ++;
 		}
 
+		// time to fill current entry
 		if( last_index == arr[0])
 		{
 			gchar *utf8_name = _utf8str( name );
@@ -4121,7 +4124,7 @@ static void load_effectchain_info()
 			gchar *mixing = _utf8str(tmp);
 
 			gtk_list_store_append( store, &iter );
-			GdkPixbuf *toggle = update_pixmap_entry( info->uc.entry_tokens[ENTRY_VIDEO_ENABLED] );
+			GdkPixbuf *toggle = update_pixmap_entry( arr[3] );
 			GdkPixbuf *kf_togglepf = update_pixmap_kf( info->uc.entry_tokens[ENTRY_KF_STATUS] );
 			gtk_list_store_set( store, &iter,
 			                   FXC_ID, arr[0],
@@ -4137,6 +4140,8 @@ static void load_effectchain_info()
 		}
 		offset += 8;
 	}
+
+	// finally clean list end
 	while( last_index < 20 )
 	{
 		gtk_list_store_append( store, &iter );

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -4056,7 +4056,7 @@ static void load_effectchain_info()
 	GtkWidget *tree = glade_xml_get_widget_( info->main_window, "tree_chain");
 	GtkListStore *store;
 	gchar toggle[4];
-	guint arr[6];
+	guint arr[VIMS_CHAIN_LIST_ENTRY_VALUES];
 	GtkTreeIter iter;
 	gint offset=0;
 
@@ -4074,7 +4074,7 @@ static void load_effectchain_info()
 	if(fxlen <= 0 )
 	{
 		int i;
-		for( i = 0; i < 20; i ++ )
+		for( i = 0; i < SAMPLE_MAX_EFFECTS; i ++ )
 		{
 			gtk_list_store_append(store,&iter);
 			gtk_list_store_set(store,&iter, FXC_ID, i ,-1);
@@ -4090,13 +4090,13 @@ static void load_effectchain_info()
 
 	while( offset < fxlen )
 	{
-		char line[12];
+		char line[VIMS_CHAIN_LIST_ENTRY_LENGHT];
 		veejay_memset(arr,0,sizeof(arr));
 		veejay_memset(line,0,sizeof(line));
 
-		strncpy( line, fxtext + offset, 8 );
-		sscanf( line, "%02d%03d%1d%1d%1d",
-			&arr[0],&arr[1],&arr[2],&arr[3],&arr[4]);
+		strncpy( line, fxtext + offset, VIMS_CHAIN_LIST_ENTRY_LENGHT );
+		sscanf( line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
+		       &arr[0],&arr[1],&arr[2],&arr[3],&arr[4],&arr[5],&arr[6]); // FIXME How to use of VIMS_CHAIN_LIST_ENTRY_VALUES ?
 
 		char *name = _effect_get_description( arr[1] );
 		snprintf(toggle,sizeof(toggle),"%s",arr[3] == 1 ? "on" : "off" );
@@ -4114,9 +4114,9 @@ static void load_effectchain_info()
 		{
 			gchar *utf8_name = _utf8str( name );
 			char  tmp[128];
-			if( _effect_get_mix( arr[0] ) ) {
-				snprintf(tmp,sizeof(tmp),"%s %d", (info->uc.entry_tokens[ENTRY_SOURCE] == 0 ? "Sample " : "T " ),
-					info->uc.entry_tokens[ENTRY_CHANNEL]);
+			if( _effect_get_mix( arr[1] ) ) {
+				snprintf(tmp,sizeof(tmp),"%s %d", (arr[5] == 0 ? "Sample " : "T " ),
+					arr[6]);
 			}
 			else {
 				snprintf(tmp,sizeof(tmp),"%s"," ");
@@ -4138,11 +4138,11 @@ static void load_effectchain_info()
 			g_object_unref( toggle );
 			g_object_unref( kf_togglepf );
 		}
-		offset += 8;
+		offset += VIMS_CHAIN_LIST_ENTRY_LENGHT;
 	}
 
 	// finally clean list end
-	while( last_index < 20 )
+	while( last_index < SAMPLE_MAX_EFFECTS )
 	{
 		gtk_list_store_append( store, &iter );
 		gtk_list_store_set( store, &iter,

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -2473,7 +2473,7 @@ static void vj_kf_reset()
 	GtkWidget *curve = glade_xml_get_widget_(info->main_window, "curve");
 
 	reset_curve( curve );
-	set_toggle_button( "curve_toggleentry", 0 );
+	set_toggle_button( "curve_chain_toggleentry", 0 );
 	set_toggle_button( "curve_toggleentry_param", 0);
 	update_label_str( "curve_parameter",FX_PARAMETER_DEFAULT_NAME);
 }
@@ -3967,7 +3967,7 @@ static gint load_parameter_info()
 		info->uc.selected_rgbkey = 0;
 	}
 
-	set_toggle_button( "curve_toggleentry", p[ENTRY_KF_STATUS] );
+	set_toggle_button( "curve_chain_toggleentry", p[ENTRY_KF_STATUS] );
 
 	if(info->status_tokens[PLAY_MODE] == MODE_SAMPLE )
 	{

--- a/veejay-current/veejay-server/veejay/vims.h
+++ b/veejay-current/veejay-server/veejay/vims.h
@@ -280,9 +280,9 @@ enum {
 	VIMS_VLOOPBACK_STOP				=	46,
 };
 
-#define VIMS_CHAIN_LIST_ENTRY_LENGHT 12 // Size of sub message anwser (real size if SAMPLE_MAX_EFFECTS * VIMS_CHAIN_LIST_ENTRY_LENGHT)
-#define VIMS_CHAIN_LIST_ENTRY_FORMAT "%02d%03d%1d%1d%1d%1d%03d"
-#define VIMS_CHAIN_LIST_ENTRY_VALUES 7 // Number of values of the message
+#define VIMS_CHAIN_LIST_ENTRY_LENGHT 13 // Size of sub message anwser (real size if SAMPLE_MAX_EFFECTS * VIMS_CHAIN_LIST_ENTRY_LENGHT)
+#define VIMS_CHAIN_LIST_ENTRY_FORMAT "%02d%03d%1d%1d%1d%1d%03d%1d"
+#define VIMS_CHAIN_LIST_ENTRY_VALUES 8 // Number of values of the message
 
 enum {
     VJ_PLAYBACK_MODE_PLAIN = 2,

--- a/veejay-current/veejay-server/veejay/vims.h
+++ b/veejay-current/veejay-server/veejay/vims.h
@@ -280,6 +280,9 @@ enum {
 	VIMS_VLOOPBACK_STOP				=	46,
 };
 
+#define VIMS_CHAIN_LIST_ENTRY_LENGHT 12 // Size of sub message anwser (real size if SAMPLE_MAX_EFFECTS * VIMS_CHAIN_LIST_ENTRY_LENGHT)
+#define VIMS_CHAIN_LIST_ENTRY_FORMAT "%02d%03d%1d%1d%1d%1d%03d"
+#define VIMS_CHAIN_LIST_ENTRY_VALUES 7 // Number of values of the message
 
 enum {
     VJ_PLAYBACK_MODE_PLAIN = 2,

--- a/veejay-current/veejay-server/veejay/vj-event.c
+++ b/veejay-current/veejay-server/veejay/vj-event.c
@@ -8899,12 +8899,10 @@ void	vj_event_send_chain_entry_parameters	( 	void *ptr,	const char format[],	va_
 	}
 }
 
-
-
 void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 {
 	int i;
-	char line[18];
+	char line[VIMS_CHAIN_LIST_ENTRY_LENGHT];
 	int args[1];
 	char *str = NULL;
 	veejay_t *v = (veejay_t*)ptr;
@@ -8916,7 +8914,7 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 	if(SAMPLE_PLAYING(v))
 	{
 		SAMPLE_DEFAULTS(args[0]);
-		char *print_buf = get_print_buf(16*SAMPLE_MAX_EFFECTS);
+		char *print_buf = get_print_buf(VIMS_CHAIN_LIST_ENTRY_LENGHT * SAMPLE_MAX_EFFECTS);
 		for(i=0; i < SAMPLE_MAX_EFFECTS; i++)
 		{
 			int effect_id = sample_get_effect_any(args[0], i);
@@ -8925,13 +8923,17 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 				int is_video = vj_effect_get_extra_frame(effect_id);
 				int using_effect = sample_get_chain_status(args[0], i);
 				int using_audio = 0;
+				int chain_source = sample_get_chain_source(args[0], i);
+				int chain_channel = sample_get_chain_channel(args[0], i);
 				//int using_audio = sample_get_chain_audio(args[0],i);
-				sprintf(line,"%02d%03d%1d%1d%1d",
+				sprintf(line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
 					i,
 					effect_id,
 					is_video,
 					(using_effect <= 0  ? 0 : 1 ),
-					(using_audio  <= 0  ? 0 : 1 )
+					(using_audio  <= 0  ? 0 : 1 ),
+					chain_source,
+					chain_channel
 				);
 						
 				APPEND_MSG(print_buf,line);
@@ -8944,7 +8946,7 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 	else if(STREAM_PLAYING(v))
 	{
 		STREAM_DEFAULTS(args[0]);
-		char *print_buf = get_print_buf(16*SAMPLE_MAX_EFFECTS);
+		char *print_buf = get_print_buf(VIMS_CHAIN_LIST_ENTRY_LENGHT * SAMPLE_MAX_EFFECTS);
 
 		for(i=0; i < SAMPLE_MAX_EFFECTS; i++) 
 		{
@@ -8953,12 +8955,16 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 			{
 				int is_video = vj_effect_get_extra_frame(effect_id);
 				int using_effect = vj_tag_get_chain_status(args[0],i);
-				sprintf(line, "%02d%03d%1d%1d%1d",
+				int chain_source = sample_get_chain_source(args[0], i);
+				int chain_channel = sample_get_chain_channel(args[0], i);
+				sprintf(line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
 					i,
 					effect_id,
 					is_video,
 					(using_effect <= 0  ? 0 : 1 ),
-					0
+					0,
+					chain_source,
+					chain_channel
 				);
 				APPEND_MSG(print_buf, line);
 			}

--- a/veejay-current/veejay-server/veejay/vj-event.c
+++ b/veejay-current/veejay-server/veejay/vj-event.c
@@ -8925,7 +8925,10 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 				int using_audio = 0;
 				int chain_source = sample_get_chain_source(args[0], i);
 				int chain_channel = sample_get_chain_channel(args[0], i);
+				int kf_type = 0;
+				int kf_status = sample_get_kf_status( args[0], i, &kf_type );
 				//int using_audio = sample_get_chain_audio(args[0],i);
+
 				sprintf(line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
 					i,
 					effect_id,
@@ -8933,7 +8936,8 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 					(using_effect <= 0  ? 0 : 1 ),
 					(using_audio  <= 0  ? 0 : 1 ),
 					chain_source,
-					chain_channel
+					chain_channel,
+					kf_status
 				);
 						
 				APPEND_MSG(print_buf,line);
@@ -8957,6 +8961,9 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 				int using_effect = vj_tag_get_chain_status(args[0],i);
 				int chain_source = sample_get_chain_source(args[0], i);
 				int chain_channel = sample_get_chain_channel(args[0], i);
+				int kf_type = 0;
+				int kf_status = sample_get_kf_status( args[0], i, &kf_type ); // exist for streaù ? or 0 ?
+
 				sprintf(line, VIMS_CHAIN_LIST_ENTRY_FORMAT,
 					i,
 					effect_id,
@@ -8964,7 +8971,8 @@ void	vj_event_send_chain_list		( 	void *ptr,	const char format[],	va_list ap	)
 					(using_effect <= 0  ? 0 : 1 ),
 					0,
 					chain_source,
-					chain_channel
+					chain_channel,
+					kf_status
 				);
 				APPEND_MSG(print_buf, line);
 			}


### PR DESCRIPTION
## Reloaded
### tree chain
- _Fix_ - "tree chain" : FX active (enable/disable) state
- _Fix_ - "tree chain" : FX Sample Mix update on sample change (change in both client/server)
### Anim FX
- _Fix_ - "Anim Fx" / "tree chain" : Anim status (enable/disable) state (change in both client/server)
- _Enhancement_ - "Anim Fx" : Add a toggle button in "curve panel" for "Key frame Anim" (siamese to toggle anim from "fx chain") 
- _Fix_ - "Anim Fx" : Anim stop kf_none --> kf_pXX
- _Fix_ - "Anim Fx" : On toggle AnimFX, update "tree_chain" FX KF Bulb
- _Enhancement_ - " Anim Fx" : update the curve on curve stored.
- _Fix_ - "Anim FX" : First click "on_kf_p0_toggled" do nothing
### Other
- _Enhancement_ - "save sample list" better tooltip
- Clean duplicate code.
- Minor optimizations : less call to "glade_xml_get_widget"
