### PR TITLE
Reloaded : Filter effects by keyword + minors stuff

### DIFF
--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -4500,6 +4500,25 @@
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkEntry" id="filter_effects">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                            <signal name="activate" handler="on_filter_effects_activate" />
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -3398,6 +3398,30 @@ void	on_image_effects_toggled(GtkWidget *w, gpointer user_data)
 		 gtk_notebook_set_page(GTK_NOTEBOOK(n),1);
 }
 
+void	on_filter_effects_activate(GtkWidget *widget, gpointer user_data)
+{
+}
+
+void	on_filter_effects_changed( GtkWidget *w, EffectListData *user_data)
+{
+	gchar* fx_txt = get_text("filter_effects");
+	int filterlen = strlen(fx_txt);
+
+	if(filterlen) {
+		vj_msg(VEEJAY_MSG_INFO, "filtering effects '%s'", fx_txt);
+		user_data->filter_string = vj_calloc(sizeof(gchar)*filterlen);  // FIXME mem LEAK
+		strcpy(user_data->filter_string, fx_txt);
+		gtk_tree_model_filter_refilter (user_data->effect_list_stores[0].effect_list_filtered);
+		gtk_tree_model_filter_refilter (user_data->effect_list_stores[1].effect_list_filtered);
+		gtk_tree_model_filter_refilter (user_data->effect_list_stores[2].effect_list_filtered);
+
+		free(user_data->filter_string);
+		user_data->filter_string = NULL;
+	} else {
+		vj_msg(VEEJAY_MSG_INFO, "");
+	}
+}
+
 void	on_console1_activate(GtkWidget *w, gpointer user_data)
 {
 	GtkWidget *n = glade_xml_get_widget_( info->main_window, "panels" );

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -3402,23 +3402,30 @@ void	on_filter_effects_activate(GtkWidget *widget, gpointer user_data)
 {
 }
 
-void	on_filter_effects_changed( GtkWidget *w, EffectListData *user_data)
+void	on_filter_effects_changed( GtkWidget *w, effectlist_data *user_data)
 {
-	gchar* fx_txt = get_text("filter_effects");
-	int filterlen = strlen(fx_txt);
+	if(user_data != NULL) {
+		gchar* fx_txt = get_text("filter_effects");
+		int filterlen = strlen(fx_txt);
 
-	if(filterlen) {
-		vj_msg(VEEJAY_MSG_INFO, "filtering effects '%s'", fx_txt);
-		user_data->filter_string = vj_calloc(sizeof(gchar)*filterlen);  // FIXME mem LEAK
-		strcpy(user_data->filter_string, fx_txt);
-		gtk_tree_model_filter_refilter (user_data->effect_list_stores[0].effect_list_filtered);
-		gtk_tree_model_filter_refilter (user_data->effect_list_stores[1].effect_list_filtered);
-		gtk_tree_model_filter_refilter (user_data->effect_list_stores[2].effect_list_filtered);
-
-		free(user_data->filter_string);
-		user_data->filter_string = NULL;
-	} else {
-		vj_msg(VEEJAY_MSG_INFO, "");
+		if(filterlen) {
+			vj_msg(VEEJAY_MSG_INFO, "filtering effects '%s'", fx_txt);
+			user_data->filter_string = g_new0(gchar, filterlen+1);
+			if(user_data->filter_string != NULL) {
+				strcpy(user_data->filter_string, fx_txt);
+				gtk_tree_model_filter_refilter (user_data->stores[0].filtered);
+				gtk_tree_model_filter_refilter (user_data->stores[1].filtered);
+				gtk_tree_model_filter_refilter (user_data->stores[2].filtered);
+				g_free(user_data->filter_string);
+			}
+			user_data->filter_string = NULL;
+		} else {
+			vj_msg(VEEJAY_MSG_DEBUG, ""); // FIXME why debug ? check vj-msg.h and "void vj_msg( " from vj-api.c:2340
+			// filter with "user_data->filter_string = NULL" to remove the filter
+			gtk_tree_model_filter_refilter (user_data->stores[0].filtered);
+			gtk_tree_model_filter_refilter (user_data->stores[1].filtered);
+			gtk_tree_model_filter_refilter (user_data->stores[2].filtered);
+		}
 	}
 }
 

--- a/veejay-current/veejay-client/src/callback.h
+++ b/veejay-current/veejay-client/src/callback.h
@@ -21,36 +21,6 @@
 #define VJCALLBACK_H
 
 
-typedef struct
-{
-    GtkListStore       *effect_list;
-    GtkTreeModelSort   *effect_list_sorted;
-    GtkTreeModelFilter *effect_list_filtered;
-} EffectListStore;
-
-typedef struct
-{
-	EffectListStore effect_list_stores[3];
-	gchar              *filter_string;
-} EffectListData;
-
-
-/*
-struct _PhotosPreviewModel
-{
-  GtkTreeModelFilter parent_instance;
-  PhotosBaseManager *item_mngr;
-};
-
-struct _PhotosPreviewModelClass
-{
-  GtkTreeModelFilterClass parent_class;
-};
-
-
-G_DEFINE_TYPE (PhotosPreviewModel, photos_preview_model, GTK_TYPE_TREE_MODEL_FILTER);*/
-
-
 #define	SLIDER_CHANGED( arg_num, value ) \
 {\
 if(!info->status_lock && !info->parameter_lock)\

--- a/veejay-current/veejay-client/src/callback.h
+++ b/veejay-current/veejay-client/src/callback.h
@@ -20,6 +20,37 @@
 #ifndef VJCALLBACK_H
 #define VJCALLBACK_H
 
+
+typedef struct
+{
+    GtkListStore       *effect_list;
+    GtkTreeModelSort   *effect_list_sorted;
+    GtkTreeModelFilter *effect_list_filtered;
+} EffectListStore;
+
+typedef struct
+{
+	EffectListStore effect_list_stores[3];
+	gchar              *filter_string;
+} EffectListData;
+
+
+/*
+struct _PhotosPreviewModel
+{
+  GtkTreeModelFilter parent_instance;
+  PhotosBaseManager *item_mngr;
+};
+
+struct _PhotosPreviewModelClass
+{
+  GtkTreeModelFilterClass parent_class;
+};
+
+
+G_DEFINE_TYPE (PhotosPreviewModel, photos_preview_model, GTK_TYPE_TREE_MODEL_FILTER);*/
+
+
 #define	SLIDER_CHANGED( arg_num, value ) \
 {\
 if(!info->status_lock && !info->parameter_lock)\

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -6921,17 +6921,22 @@ static void process_reload_hints(int *history, int pm)
 		if( entry_tokens[ENTRY_FXID] == 0)
 		{
 			put_text( "entry_effectname" ,"" );
+			// disable fx widgets but keep "button_fx_entry" enabled
 			disable_widget( "frame_fxtree2" );
-			disable_widget( "frame_fxtree4" );
+			disable_widget( "entry_effectname");
+			disable_widget( "button_entry_toggle");
 			disable_widget( "tree_sources");
 			disable_widget( "rgbkey");
+			set_toggle_button( "button_entry_toggle"), FALSE );
 			update_label_str( "value_friendlyname", FX_PARAMETER_VALUE_DEFAULT_HINT );
 		}
 		else
 		{
 			put_text( "entry_effectname", _effect_get_description( entry_tokens[ENTRY_FXID] ));
+			// enable fx widgets
 			enable_widget( "frame_fxtree2");
-			enable_widget( "frame_fxtree4");
+			enable_widget( "entry_effectname");
+			enable_widget( "button_entry_toggle");
 			enable_widget( "tree_sources");
 			enable_widget( "rgbkey" );
 			set_toggle_button( "button_entry_toggle", entry_tokens[ENTRY_VIDEO_ENABLED] );

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -122,10 +122,11 @@ static struct
 	const char *text;
 } tooltips[] =
 {
-	{"Mouse left: Set in point, Mouse right: Set out point, Double click: Clear selected, Mouse middle: Drag selection"},
-	{"Mouse left/right: Play slot, Shift + Mouse left: Put sample in slot. You can also put selected samples."},
-	{"Mouse left click: Select slot (sample in slot), Mouse double click: Play sample in slot, Mouse left + SHIFT: Set slot as mixing current mixing channel"},
+	{"Mouse left: Set in point,\nMouse right: Set out point,\nDouble click: Clear selected,\nMouse middle: Drag selection"},
+	{"Mouse left/right: Play slot,\nShift + Mouse left: Put sample in slot.\nYou can also put selected samples."},
+	{"Mouse left click: Select slot (sample in slot),\nMouse double click: Play sample in slot,\nShift + Mouse left: Set slot as mixing current mixing channel"},
 	{"Select a SRT sequence to edit"},
+	{"Double click: add effect to chain list,\nShift + Double click: add disabled effect to chain list"},
 	{NULL},
 };
 
@@ -134,7 +135,8 @@ enum
 	TOOLTIP_TIMELINE = 0,
 	TOOLTIP_QUICKSELECT = 1,
 	TOOLTIP_SAMPLESLOT = 2,
-	TOOLTIP_SRTSELECT = 3
+	TOOLTIP_SRTSELECT = 3,
+	TOOLTIP_FXSELECT = 4
 };
 
 #define FX_PARAMETER_DEFAULT_NAME "<none>"
@@ -3888,7 +3890,6 @@ static void setup_effectchain_info( void )
 	setup_tree_text_column( "tree_chain", FXC_MIXING, "Channel",0);
 	GtkTreeSelection *selection;
 
-	tree = glade_xml_get_widget_( info->main_window, "tree_chain");
 	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(tree));
 	gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
 	gtk_tree_selection_set_select_function(selection, view_entry_selection_func, NULL, NULL);
@@ -4328,6 +4329,10 @@ void setup_effectlist_info()
 	trees[0] = glade_xml_get_widget_( info->main_window, "tree_effectlist");
 	trees[1] = glade_xml_get_widget_( info->main_window, "tree_effectmixlist");
 	trees[2] = glade_xml_get_widget_( info->main_window, "tree_alphalist" );
+
+	set_tooltip_by_widget (trees[0], tooltips[TOOLTIP_FXSELECT].text);
+	set_tooltip_by_widget (trees[1], tooltips[TOOLTIP_FXSELECT].text);
+	set_tooltip_by_widget (trees[2], tooltips[TOOLTIP_FXSELECT].text);
 
 	GtkListStore *stores[3];
 

--- a/veejay-current/veejay-server/libvje/effects/colorhis.c
+++ b/veejay-current/veejay-server/libvje/effects/colorhis.c
@@ -76,7 +76,7 @@ int	colorhis_malloc(int w, int h)
 	rgb_ = vj_malloc(sizeof(uint8_t) * w * h * 3 );
 	if(rgb_ == NULL )
 		return 0;
-	rgb_frame_ = yuv_rgb_template( rgb_, w, h, PIX_FMT_RGB24 );
+	rgb_frame_ = yuv_rgb_template( rgb_, w, h, AV_PIX_FMT_RGB24 );
 	if(rgb_frame_ == NULL)
 		return 0;
 
@@ -107,10 +107,10 @@ void	colorhis_free()
 
 void colorhis_apply( VJFrame *frame,int mode, int val, int intensity, int strength)
 {
-	int src_fmt = (frame->uv_height == frame->height ? PIX_FMT_YUV422P : PIX_FMT_YUV420P);
+	int src_fmt = (frame->uv_height == frame->height ? AV_PIX_FMT_YUV422P : AV_PIX_FMT_YUV420P);
 
 	if(!convert_yuv)
-		convert_yuv = yuv_fx_context_create( frame, rgb_frame_, src_fmt, PIX_FMT_RGB24 );
+		convert_yuv = yuv_fx_context_create( frame, rgb_frame_, src_fmt, AV_PIX_FMT_RGB24 );
 
 	yuv_fx_context_process( convert_yuv, frame, rgb_frame_ );
 
@@ -124,7 +124,7 @@ void colorhis_apply( VJFrame *frame,int mode, int val, int intensity, int streng
 		veejay_histogram_equalize_rgb( histogram_, frame, rgb_, intensity, strength, mode );
 
 		if(!convert_rgb )
-			convert_rgb = yuv_fx_context_create( rgb_frame_, frame, PIX_FMT_RGB24, src_fmt );
+			convert_rgb = yuv_fx_context_create( rgb_frame_, frame, AV_PIX_FMT_RGB24, src_fmt );
 		yuv_fx_context_process( convert_rgb, rgb_frame_, frame );
 	}
 }

--- a/veejay-current/veejay-server/libvje/effects/picinpic.c
+++ b/veejay-current/veejay-server/libvje/effects/picinpic.c
@@ -120,7 +120,7 @@ void picinpic_apply( void *user_data, VJFrame *frame, VJFrame *frame2,
 		return; // nothing to do
 
 	// sub_format up is always 4:4:4 planar
-	int pixfmt = (frame->format == PIX_FMT_YUVJ422P ? PIX_FMT_YUVJ444P: PIX_FMT_YUV444P);
+	int pixfmt = (frame->format == AV_PIX_FMT_YUVJ422P ? AV_PIX_FMT_YUVJ444P: AV_PIX_FMT_YUV444P);
 	VJFrame src;
 	veejay_memcpy(&src,frame2,sizeof(VJFrame));
 	src.format = pixfmt;

--- a/veejay-current/veejay-server/test/README
+++ b/veejay-current/veejay-server/test/README
@@ -9,18 +9,26 @@ In this directory:
  examples/
 	perl scripts that generate the files in vims/ are found here
 
+ keyboard/
+	veejay simple keyboard layout
+
  livecinema/
-	action-file.xml  	;example action file for veejay , run with -l or --action-file 
-	     
+	action-file.xml  	;example action file for veejay , run with -l or --action-file
+
+ videowall/
+	split screen configuration shell example.
+
  vims/
 	the files in this directory can be send to veejay, it demonstrates series of effect chains.
 
-	sendVIMS -f montevideo-auto.txt
+ $ sayVIMS -f montevideo-auto.txt
 
 
  Example to produce a vims file and to send it to veejay:
 
  $ perl examples/swirl.nl > vims/swirl.vims
 
- $ sendVIMS -f vims/swirl.vims
+ $ sayVIMS -f vims/swirl.vims
  
+ youtube/
+	simple bash script that encodes a youtube video to mjpeg avi file with audio for use in veejay


### PR DESCRIPTION
Work on User Experience on and around Effects.

## Filter effects by keyword
* add text entry control right to fx types select box.
* add filtered and sorted models to effect trees
* on user input the filter effect trees is interactivly filtred (no case sensitive)

related to #47

## Add  fx to selected sample (ctrl + double click over effects list)
* Add the selected effect from the effect list to the selected sample (single click over sample bank, effect color blue)

## Fx entry button always enable.
* Easy access to the chain list even if the "Fx Chain" panel is not visible.

### Add disabled fx (shift + double click over effects list)
* **FIX** 

## other stuff
* Documentation
* veejay : AV_ Prefix !
* reloaded : improve fx list and sample tooltips 

