### PR TITLE
 Reloaded3 - FX Anim, save space (fx param select using combo)  + fixes

### DIFF
--- a/veejay-current/reloaded-gtk3/share/gveejay.reloaded.css
+++ b/veejay-current/reloaded-gtk3/share/gveejay.reloaded.css
@@ -35,6 +35,10 @@
  border-color:#9ec5e3;
 }
 
+.smallaspossible {
+    min-height: 0px;
+    min-width: 0px;
+}
 
 checkbutton,radiobutton {
  border-style:none;
@@ -56,9 +60,11 @@ button:hover image, button:hover label {
   background-color:#ff8400;
 }
 
+/*
 spinbutton {
  border-width:4px;
 }
+*/
 
 entry:focus {
  background-color:#626580;

--- a/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
+++ b/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
@@ -1454,6 +1454,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -14078,6 +14084,7 @@
                                             <property name="can_focus">True</property>
                                             <property name="margin_bottom">8</property>
                                             <property name="orientation">vertical</property>
+                                            <property name="adjustment">gen_p8</property>
                                             <property name="inverted">True</property>
                                             <property name="round_digits">0</property>
                                             <property name="digits">0</property>

--- a/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
+++ b/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
@@ -1448,6 +1448,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -8235,7 +8241,7 @@
                                     <property name="label" translatable="yes">Selected FX parameter:</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
+                                    <property name="left_attach">2</property>
                                     <property name="top_attach">0</property>
                                   </packing>
                                 </child>
@@ -8248,7 +8254,59 @@
                                     <signal name="changed" handler="on_curve_fx_param_changed" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
+                                    <property name="left_attach">3</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox850">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkToggleButton" id="curve_panel_toggleentry">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Toggle rendering of this animation in FX chain</property>
+                                        <signal name="toggled" handler="curve_panel_toggleentry_toggled" swapped="no"/>
+                                        <child>
+                                          <object class="GtkImage" id="image58">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="pixbuf">icon_keyframe.png</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="curve_buttonclear">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Reset all animated parameters</property>
+                                        <signal name="clicked" handler="on_curve_buttonclear_clicked" swapped="no"/>
+                                        <child>
+                                          <object class="GtkImage" id="image532">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="pixbuf">icon_clearall.png</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
                                     <property name="top_attach">0</property>
                                   </packing>
                                 </child>
@@ -8431,7 +8489,7 @@
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">True</property>
+                            <property name="fill">False</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
@@ -8452,61 +8510,8 @@
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="hbox850">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkToggleButton" id="curve_panel_toggleentry">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Toggle rendering of this animation in FX chain</property>
-                                <signal name="toggled" handler="curve_panel_toggleentry_toggled" swapped="no"/>
-                                <child>
-                                  <object class="GtkImage" id="image58">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="pixbuf">icon_keyframe.png</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="curve_buttonclear">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Reset all animated parameters</property>
-                                <signal name="clicked" handler="on_curve_buttonclear_clicked" swapped="no"/>
-                                <child>
-                                  <object class="GtkImage" id="image532">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="pixbuf">icon_clearall.png</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
                             <property name="fill">False</property>
-                            <property name="position">4</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -8573,8 +8578,9 @@
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">5</property>
+                            <property name="fill">False</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>

--- a/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
+++ b/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
@@ -8468,19 +8468,6 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_left">8</property>
-                                    <property name="margin_right">8</property>
-                                    <property name="label" translatable="yes">Selected FX parameter:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
                                   <object class="GtkRadioButton" id="kf_none">
                                     <property name="label" translatable="yes">None</property>
                                     <property name="visible">True</property>
@@ -8517,6 +8504,84 @@
                                     <property name="left_attach">0</property>
                                     <property name="top_attach">0</property>
                                   </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_left">8</property>
+                                    <property name="margin_right">8</property>
+                                    <property name="label" translatable="yes">Selected FX parameter:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBoxText" id="combo_curve_fx_param">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <signal name="changed" handler="on_curve_fx_param_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>

--- a/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
+++ b/veejay-current/reloaded-gtk3/share/gveejay.reloaded.glade
@@ -1442,6 +1442,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -8197,295 +8203,10 @@
                               <object class="GtkGrid">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="column_spacing">9</property>
                                 <child>
-                                  <object class="GtkRadioButton" id="kf_p15">
-                                    <property name="label" translatable="yes">15</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p15</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p15_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">18</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p14">
-                                    <property name="label" translatable="yes">14</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p14</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p14_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">17</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p13">
-                                    <property name="label" translatable="yes">13</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p13</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p13_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">16</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p12">
-                                    <property name="label" translatable="yes">12</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p12</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p12_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">15</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p11">
-                                    <property name="label" translatable="yes">11</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p11</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p11_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">14</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p10">
-                                    <property name="label" translatable="yes">10</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p10</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p10_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">13</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p9">
-                                    <property name="label" translatable="yes">9</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p9</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="group-changed" handler="on_kf_p9_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">12</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p8">
-                                    <property name="label" translatable="yes">8</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p8</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">11</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p7">
-                                    <property name="label" translatable="yes">7</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p7</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p7_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">10</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p6">
-                                    <property name="label" translatable="yes">6</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p6</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p6_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">9</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p5">
-                                    <property name="label" translatable="yes">5</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p5</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p5_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">8</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p4">
-                                    <property name="label" translatable="yes">4</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p4</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p4_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">7</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p3">
-                                    <property name="label" translatable="yes">3</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p3</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p3_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">6</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p2">
-                                    <property name="label" translatable="yes">2</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p2_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">5</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p1">
-                                    <property name="label" translatable="yes">1</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p1</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p1_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">4</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_p0">
-                                    <property name="label" translatable="yes">0</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Select parameter p0</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">kf_none</property>
-                                    <signal name="toggled" handler="on_kf_p0_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="kf_none">
-                                    <property name="label" translatable="yes">None</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="yalign">0.5</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <signal name="toggled" handler="on_kf_none_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="curve_parameter">
+                                  <object class="GtkLabel" id="label_effectanim_name">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="halign">center</property>
@@ -8520,68 +8241,16 @@
                                 </child>
                                 <child>
                                   <object class="GtkComboBoxText" id="combo_curve_fx_param">
+                                    <property name="width_request">10</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="popup_fixed_width">False</property>
                                     <signal name="changed" handler="on_curve_fx_param_changed" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left_attach">2</property>
+                                    <property name="top_attach">0</property>
                                   </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>

--- a/veejay-current/reloaded-gtk3/src/callback.c
+++ b/veejay-current/reloaded-gtk3/src/callback.c
@@ -3392,7 +3392,7 @@ void	on_curve_spinstart_value_changed(GtkWidget *w, gpointer user_data)
 
 	char *start_time = format_time(
 			start_pos,info->el.fps );
-	update_label_str( "curve_endtime", start_time );
+	update_label_str( "curve_starttime", start_time );
 	free(start_time);
 
     gtk3_curve_set_x_lo( info->curve, (gfloat) start_pos );

--- a/veejay-current/reloaded-gtk3/src/callback.c
+++ b/veejay-current/reloaded-gtk3/src/callback.c
@@ -2788,6 +2788,9 @@ void	on_curve_buttonclear_clicked(GtkWidget *widget, gpointer user_data)
 
     info->uc.reload_hint[HINT_KF] = 1;
 
+    GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+    gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param), 0); // <None>
+
     if(!is_button_toggled("kf_none")) {
         set_toggle_button("kf_none",1);
     }
@@ -2921,6 +2924,32 @@ void	curve_panel_toggleentry_toggled( GtkWidget *widget, gpointer user_data)
 	}
 }
 
+void on_curve_fx_param_changed(GtkComboBox *widget, gpointer user_data)
+{
+    GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+    gchar *active_kf = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT(kf_param));//DEBUG
+    gint active_kf_id = gtk_combo_box_get_active (GTK_COMBO_BOX(kf_param));
+    if (active_kf_id != -1) {
+        if(active_kf_id == 0){
+            info->uc.selected_parameter_id = -1;
+
+            disable_widget( "fxanimcontrols" );
+            disable_widget( "curve_container" );
+
+            if(info->status_lock)
+              return;
+
+            vj_kf_reset();
+        } else {
+            KF_CHANGED (active_kf_id -1); ////None is id 0
+            enable_widget( "fxanimcontrols" );
+            enable_widget( "curve_container" );
+        }
+        veejay_msg(VEEJAY_MSG_INFO,"kf param changed !!! %s ", active_kf);//DEBUG
+        g_free(active_kf);//DEBUG
+    }
+}
+/*
 void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if(gtk_toggle_button_get_active( widget ))
@@ -2940,7 +2969,8 @@ void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
         enable_widget("curve_container");
     }
 }
-
+*/
+/*
 void	on_kf_p0_toggled( GtkToggleButton *widget, gpointer user_data)
 {
 	if(gtk_toggle_button_get_active( widget ))
@@ -3028,7 +3058,7 @@ void	on_kf_p15_toggled( GtkToggleButton *widget, gpointer user_data)
 	if(gtk_toggle_button_get_active( widget ))
 		KF_CHANGED( 15 );
 }
-
+*/
 void	on_button_videobook_clicked(GtkWidget *widget, gpointer user_data)
 {
 	GtkWidget *n = glade_xml_get_widget_( info->main_window, "videobook" );

--- a/veejay-current/reloaded-gtk3/src/callback.c
+++ b/veejay-current/reloaded-gtk3/src/callback.c
@@ -2791,9 +2791,6 @@ void	on_curve_buttonclear_clicked(GtkWidget *widget, gpointer user_data)
     GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
     gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param), 0); // <None>
 
-    if(!is_button_toggled("kf_none")) {
-        set_toggle_button("kf_none",1);
-    }
     reset_curve(info->curve);
 }
 
@@ -2949,116 +2946,7 @@ void on_curve_fx_param_changed(GtkComboBox *widget, gpointer user_data)
         g_free(active_kf);//DEBUG
     }
 }
-/*
-void	on_kf_none_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-	{
-		info->uc.selected_parameter_id = -1;
 
-		disable_widget( "fxanimcontrols" );
-		disable_widget( "curve_container" );
-
-		if(info->status_lock)
-			return;
-
-		vj_kf_reset();
-	}
-    else {
-        enable_widget("fxanimcontrols");
-        enable_widget("curve_container");
-    }
-}
-*/
-/*
-void	on_kf_p0_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 0 );
-}
-void	on_kf_p1_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 1 );
-}
-void	on_kf_p2_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 2 );
-}
-void	on_kf_p3_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 3 );
-}
-void	on_kf_p4_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 4 );
-}
-void	on_kf_p5_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 5 );
-}
-void	on_kf_p6_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 6 );
-}
-void	on_kf_p7_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 7 );
-}
-void	on_kf_p8_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 8 );
-}
-void	on_kf_p9_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 9 );
-}
-void	on_kf_p10_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 10 );
-}
-
-void	on_kf_p11_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 11 );
-}
-
-void	on_kf_p12_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 12 );
-}
-
-
-void	on_kf_p13_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 13 );
-}
-
-
-void	on_kf_p14_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 14 );
-}
-
-void	on_kf_p15_toggled( GtkToggleButton *widget, gpointer user_data)
-{
-	if(gtk_toggle_button_get_active( widget ))
-		KF_CHANGED( 15 );
-}
-*/
 void	on_button_videobook_clicked(GtkWidget *widget, gpointer user_data)
 {
 	GtkWidget *n = glade_xml_get_widget_( info->main_window, "videobook" );

--- a/veejay-current/reloaded-gtk3/src/vj-api.c
+++ b/veejay-current/reloaded-gtk3/src/vj-api.c
@@ -2771,6 +2771,10 @@ static void vj_kf_reset()
 
     //set_toggle_button( "curve_chain_toggleentry", 0 );
     //set_toggle_button( "curve_toggleentry_param", 0);
+
+    GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+    gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param),0);
+
     update_label_str( "curve_parameter",FX_PARAMETER_DEFAULT_NAME);
     info->status_lock = 0;
 }
@@ -2785,6 +2789,14 @@ static void vj_kf_refresh()
         status = update_curve_widget(info->curve);
     }
     else {
+        if(!is_button_toggled("kf_none")) {
+            GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+            gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param),0);
+            set_toggle_button("kf_none",1);
+        }
+        if(!is_button_toggled("curve_toggleentry_param")) {
+            set_toggle_button( "curve_toggleentry_param", 0 );
+        }
         disable_widget( "frame_fxtree3" );
     }
 
@@ -2798,6 +2810,8 @@ static void vj_kf_select_parameter(int num)
     sample_slot_t *s = info->selected_slot;
     if(!s)
     {
+        GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+        gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param),0);
         update_label_str( "curve_parameter", FX_PARAMETER_DEFAULT_NAME);
         return;
     }
@@ -7198,6 +7212,9 @@ static void disable_fx_entry() {
         disable_widget( fx_fade_entry[i].name );
     }
 
+    GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+    gtk_combo_box_text_remove_all(GTK_COMBO_BOX_TEXT(kf_param));
+
     for( i = 0; i < MAX_UI_PARAMETERS; i ++ )
     {
         if( !is_widget_enabled( slider_names_[i].text ) && !is_widget_enabled( param_kfs_[i].text ) )
@@ -7210,9 +7227,9 @@ static void disable_fx_entry() {
 
         set_tooltip( param_kfs_[i].text, NULL );
         set_tooltip( slider_names_[i].text, NULL );
-        
+
         gtk_label_set_text(GTK_LABEL (glade_xml_get_widget_(info->main_window,param_names_[i].text)),NULL);
-    
+
         if( faster_ui_ ) 
           hide_widget( param_frame_[i].text );
     }
@@ -7283,8 +7300,14 @@ static void enable_fx_entry() {
         }
     }
 
+    GtkWidget *kf_param = glade_xml_get_widget_(info->main_window,"combo_curve_fx_param");
+    gtk_combo_box_text_remove_all(GTK_COMBO_BOX_TEXT(kf_param));
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(kf_param), FX_PARAMETER_DEFAULT_NAME);
+    gtk_combo_box_set_active (GTK_COMBO_BOX(kf_param),0);
+
     int np = _effect_get_np( entry_tokens[ENTRY_FXID] );
     gint min,max,value;
+
     for( i = 0; i < np ; i ++ )
     {
         if( !is_widget_enabled( slider_box_names_[i].text ) ) {
@@ -7314,7 +7337,14 @@ static void enable_fx_entry() {
             update_slider_range( slider_names_[i].text,min,max, value, 0);
         }
         set_tooltip( param_kfs_[i].text, tt1 );
+
+        size_t n = 1 + 2 + 1 + strlen(tt1); // see sprintf
+        gchar *kf_param_text = (gchar*)vj_malloc(sizeof(gchar)*(n+1));
+        sprintf(kf_param_text, "p%d %s",i, tt1);
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(kf_param), kf_param_text);
+
         g_free(tt1);
+        free(kf_param_text);
     }
    
     min = 0; max = 1; value = 0; 

--- a/veejay-current/reloaded-gtk3/src/vj-api.c
+++ b/veejay-current/reloaded-gtk3/src/vj-api.c
@@ -7210,19 +7210,15 @@ static void disable_fx_entry() {
 
     for( i = 0; i < MAX_UI_PARAMETERS; i ++ )
     {
-        if( !is_widget_enabled( slider_names_[i].text ) )
-            continue;
-
         update_slider_range( slider_names_[i].text, min,max, value, 0 );
         disable_widget( slider_box_names_[i].text );
         set_tooltip( slider_names_[i].text, NULL );
 
         gtk_label_set_text(GTK_LABEL (glade_xml_get_widget_(info->main_window,param_names_[i].text)),NULL);
 
-        if( faster_ui_ ) 
-          hide_widget( param_frame_[i].text );
+        if( faster_ui_ )
+            hide_widget( param_frame_[i].text );
     }
-
 }
 
 static void enable_fx_entry() {


### PR DESCRIPTION
fixes 
* Param names was no more cleared
* move "delete anim" and "enable anim" button to top (resolve disabled btn on delete)
* curve start time label not updated
* Save Space adding css rules (djay css option now could be removed)
* Fix Camera control slide 8 (adjustement missing)