### PR TITLE
Reloaded3 - minor fixes : sample record duration + sample rename

### DIFF
--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -1535,6 +1535,12 @@
                       <placeholder/>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="generators_close">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -10841,6 +10847,7 @@
                                                     <property name="secondary_icon_activatable">False</property>
                                                     <property name="adjustment">sample_record_duration</property>
                                                     <property name="climb_rate">1</property>
+                                                    <property name="value">1</property>
                                                     <signal name="value-changed" handler="on_spin_sampleduration_value_changed" swapped="no"/>
                                                   </object>
                                                 </child>

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -216,7 +216,7 @@ void	on_entry_samplename_button_clicked( GtkWidget *widget, gpointer user_data )
 			if( (info->sample_banks[i]->slot[j]->sample_id ==
 			    info->status_tokens[CURRENT_ID]) ) 
 			{
-				gtk_frame_set_label( GTK_FRAME( info->sample_banks[i]->gui_slot[j]->frame ) , title );
+                gtk_label_set_text( GTK_LABEL( info->sample_banks[i]->gui_slot[j]->title ), title );
 				return;
 			}
 		}

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -1664,34 +1664,34 @@ void	on_button_sample_recordstop_clicked(GtkWidget *widget, gpointer user_data)
 	vj_msg(VEEJAY_MSG_INFO, "Sample record stop");
 }
 
-static	int	sample_calctime_selection()
+static inline int sample_calctime (int nframes)
 {
-	int n_frames = info->status_tokens[SAMPLE_MARKER_END] - info->status_tokens[SAMPLE_MARKER_START];
-	if( info->status_tokens[SAMPLE_LOOP] == 2 )
-		n_frames *= 2;
-	if( info->status_tokens[FRAME_DUP] > 0 )
-		n_frames *= info->status_tokens[FRAME_DUP];
+    if( info->status_tokens[SAMPLE_LOOP] == 2 )
+        nframes *= 2;
+    if( info->status_tokens[FRAME_DUP] > 0 )
+        nframes *= info->status_tokens[FRAME_DUP];
     int speed = info->status_tokens[SAMPLE_SPEED];
     if( speed == 0 )
        speed = 1;
-    n_frames = n_frames / abs(speed);
+    nframes = nframes / abs(speed);
 
-	return n_frames;
+    return nframes;
 }
 
-static	int	sample_calctime()
+static int sample_calctime_selection()
 {
-	int n_frames = info->status_tokens[SAMPLE_END] - info->status_tokens[SAMPLE_START];
-	if( info->status_tokens[SAMPLE_LOOP] == 2 )
-		n_frames *= 2;
-	if( info->status_tokens[FRAME_DUP] > 0 )
-		n_frames *= info->status_tokens[FRAME_DUP];
-    int speed = info->status_tokens[SAMPLE_SPEED];
-    if( speed == 0 )
-       speed = 1;
-    n_frames = n_frames / abs(speed);
+    int n_frames = info->status_tokens[SAMPLE_MARKER_END] - info->status_tokens[SAMPLE_MARKER_START];
+    if (n_frames == 0 )
+        n_frames = info->status_tokens[SAMPLE_END] - info->status_tokens[SAMPLE_START];
 
-	return n_frames;
+    return sample_calctime(n_frames);
+}
+
+static int sample_calctime_mulloop()
+{
+    int n_frames = info->status_tokens[SAMPLE_END] - info->status_tokens[SAMPLE_START];
+
+    return sample_calctime(n_frames);
 }
 
 void	on_spin_sampleduration_value_changed(GtkWidget *widget , gpointer user_data)
@@ -1699,7 +1699,7 @@ void	on_spin_sampleduration_value_changed(GtkWidget *widget , gpointer user_data
     int n_frames = 0;
 	// get num and display label_samplerecord_duration
 	if( is_button_toggled( "sample_mulloop" )) {
-		n_frames = sample_calctime();
+		n_frames = sample_calctime_mulloop();
         n_frames *= get_nums( "spin_sampleduration" );
     }
 	else if ( is_button_toggled( "sample_mulframes" ) ) {

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -3869,12 +3869,7 @@ static void update_record_tab(int pm)
     }
     if(pm == MODE_SAMPLE)
     {
-        update_spin_value( "spin_sampleduration", 1 );
-        // combo_samplecodec
-        gint n_frames = sample_calctime();
-        char *time = format_time( n_frames,(double) info->el.fps );
-        update_label_str( "label_samplerecord_duration", time );
-        free(time);
+        on_spin_sampleduration_value_changed(NULL,NULL);
     }
 }
 


### PR DESCRIPTION
* At startup duration value was always 0 (loop init at 0 fixed in glade)
* If no selection in timeline and record selection selected, the record
duration was set to 0 (no marker) now set to clip duration

* On sample rename, set slot title (not frame label)