### PR TITLE
Reloaded : Transition signal fixes

### DIFF
--- a/veejay-current/veejay-client/share/gveejay.reloaded.glade
+++ b/veejay-current/veejay-client/share/gveejay.reloaded.glade
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkWindow">
     <property name="can_focus">False</property>
-    <child type="titlebar">
+    <child>
       <placeholder/>
     </child>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
   </object>
   <object class="GtkApplicationWindow">
     <property name="can_focus">False</property>
-    <child type="titlebar">
+    <child>
       <placeholder/>
     </child>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
   </object>
@@ -142,9 +142,6 @@
     <property name="destroy_with_parent">True</property>
     <property name="icon">icon_stream.png</property>
     <signal name="delete-event" handler="on_generator_window_delete_event" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkFrame" id="frame_generator">
         <property name="visible">True</property>
@@ -192,6 +189,12 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="n_columns">4</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                     <child>
                       <placeholder/>
                     </child>
@@ -1671,6 +1674,9 @@
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -1722,9 +1728,6 @@
     <property name="title" translatable="yes">Image Calibration</property>
     <property name="destroy_with_parent">True</property>
     <signal name="delete-event" handler="on_calibration_window_delete_event" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkBox" id="vbox637">
         <property name="visible">True</property>
@@ -2515,6 +2518,9 @@
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -2566,9 +2572,6 @@
     <property name="default_height">400</property>
     <property name="icon">icon_stream.png</property>
     <signal name="delete-event" handler="on_inputstream_window_delete_event" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkFrame" id="frame161">
         <property name="width_request">340</property>
@@ -2930,6 +2933,9 @@
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -2941,9 +2947,6 @@
     <property name="type_hint">dialog</property>
     <signal name="close" handler="on_veejay_connection_close" swapped="no"/>
     <signal name="delete-event" handler="on_veejay_connection_close" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -3184,6 +3187,9 @@
     <action-widgets>
       <action-widget response="-7">veejay_connection_close</action-widget>
     </action-widgets>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -3349,8 +3355,6 @@
   </object>
   <object class="GtkAdjustment" id="transition_lengt">
     <property name="upper">1000000</property>
-    <property name="lower">0</property>
-    <property name="value">0</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -3437,9 +3441,6 @@
     <property name="type_hint">dialog</property>
     <signal name="close" handler="on_video_options_close" swapped="no"/>
     <signal name="delete-event" handler="on_video_options_close" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox_video_options">
         <property name="visible">True</property>
@@ -4293,6 +4294,9 @@
     <action-widgets>
       <action-widget response="-7">button117</action-widget>
     </action-widgets>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -4306,9 +4310,6 @@
     <property name="type_hint">dialog</property>
     <signal name="close" handler="on_vims_bundles_close" swapped="no"/>
     <signal name="delete-event" handler="on_vims_bundles_close" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox5">
         <property name="visible">True</property>
@@ -4682,6 +4683,9 @@
     <action-widgets>
       <action-widget response="-7">vims_bundles_close</action-widget>
     </action-widgets>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <style>
       <class name="reloaded"/>
     </style>
@@ -4705,9 +4709,6 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Reloaded</property>
     <property name="icon">veejay-icon.png</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkBox" id="veejay_box">
         <property name="visible">True</property>
@@ -11441,7 +11442,7 @@
                                             <property name="receives_default">False</property>
                                             <property name="halign">start</property>
                                             <property name="draw_indicator">True</property>
-                                            <signal name="toggled" handler="transition_set_active" swapped="no"/>
+                                            <signal name="toggled" handler="on_transition_active_toggled" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -11457,7 +11458,7 @@
                                             <property name="width_chars">6</property>
                                             <property name="adjustment">transition_shap</property>
                                             <property name="climb_rate">1</property>
-                                            <signal name="value-changed" handler="transition_shape_value_changed" swapped="no"/>
+                                            <signal name="value-changed" handler="on_transition_shape_value_changed" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -11471,7 +11472,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="adjustment">transition_lengt</property>
-                                            <signal name="value-changed" handler="transition_length_value_changed" swapped="no"/>
+                                            <signal name="value-changed" handler="on_transition_length_value_changed" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -12710,7 +12711,7 @@
                                                 <property name="receives_default">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="draw_indicator">True</property>
-                                                <signal name="toggled" handler="on_tag_transition_active_toggled" swapped="no"/>
+                                                <signal name="toggled" handler="on_transition_set_active" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -12739,7 +12740,7 @@
                                                 <property name="text" translatable="yes">0</property>
                                                 <property name="adjustment">transition_shap</property>
                                                 <property name="climb_rate">1</property>
-                                                <signal name="value-changed" handler="on_tag_transition_shape_value_changed" swapped="no"/>
+                                                <signal name="value-changed" handler="on_transition_shape_value_changed" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -12766,7 +12767,7 @@
                                                 <property name="can_focus">True</property>
                                                 <property name="text" translatable="yes">0</property>
                                                 <property name="adjustment">transition_lengt</property>
-                                                <signal name="value-changed" handler="on_tag_transition_length_value_changed" swapped="no"/>
+                                                <signal name="value-changed" handler="on_transition_length_value_changed" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -19298,6 +19299,9 @@ Events may not always be triggered if veejay is configured to keep in sync (hard
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
     <style>
       <class name="reloaded"/>

--- a/veejay-current/veejay-client/src/callback.c
+++ b/veejay-current/veejay-client/src/callback.c
@@ -3784,7 +3784,7 @@ static void set_transition(int active, int shape, int length)
 }
 
 void
-transition_length_value_changed( GtkWidget *widget, gpointer user_data)
+on_transition_length_value_changed( GtkWidget *widget, gpointer user_data)
 {
     set_transition(
             info->status_tokens[ SAMPLE_TRANSITION_ACTIVE ],
@@ -3794,7 +3794,7 @@ transition_length_value_changed( GtkWidget *widget, gpointer user_data)
 }
 
 void
-transition_shape_value_changed( GtkWidget *widget, gpointer user_data)
+on_transition_shape_value_changed( GtkWidget *widget, gpointer user_data)
 {
     set_transition(
             info->status_tokens[ SAMPLE_TRANSITION_ACTIVE ],
@@ -3804,36 +3804,7 @@ transition_shape_value_changed( GtkWidget *widget, gpointer user_data)
 }
 
 void
-transition_set_active( GtkWidget *widget, gpointer user_data)
-{
-    set_transition(
-            gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) ),
-            info->status_tokens[ SAMPLE_TRANSITION_SHAPE ],
-            info->status_tokens[ SAMPLE_TRANSITION_LENGTH ]
-            );
-}
-
-void
-on_tag_transition_length_value_changed( GtkWidget *widget, gpointer user_data)
-{
-     set_transition(
-            info->status_tokens[ SAMPLE_TRANSITION_ACTIVE ],
-            info->status_tokens[ SAMPLE_TRANSITION_SHAPE ],
-            (int) gtk_spin_button_get_value( GTK_SPIN_BUTTON(widget) )
-            );
-}
-
-void
-on_tag_transition_shape_value_changed( GtkWidget *widget, gpointer user_data)
-{
-    set_transition(
-            info->status_tokens[ SAMPLE_TRANSITION_ACTIVE ],
-            (int) gtk_spin_button_get_value( GTK_SPIN_BUTTON(widget) ),
-            info->status_tokens[ SAMPLE_TRANSITION_LENGTH ]
-            );
-}
-
-void on_tag_transition_active_toggled( GtkWidget *widget, gpointer user_data)
+on_transition_active_toggled( GtkWidget *widget, gpointer user_data)
 {
     set_transition(
             gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) ),

--- a/veejay-current/veejay-client/src/vj-api.c
+++ b/veejay-current/veejay-client/src/vj-api.c
@@ -3250,14 +3250,19 @@ static void vj_kf_reset()
 
     GtkWidget* curveparam = widget_cache[WIDGET_COMBO_CURVE_FX_PARAM];
     //block "changed" signal to prevent propagation
-    guint signal_id=g_signal_lookup("changed", GTK_TYPE_COMBO_BOX);
-    gulong handler_id=handler_id=g_signal_handler_find( (gpointer)curveparam,
+    guint signal_id = g_signal_lookup("changed", GTK_TYPE_COMBO_BOX);
+    gulong handler_id = g_signal_handler_find( (gpointer)curveparam,
                                                         G_SIGNAL_MATCH_ID,
                                                         signal_id,
                                                         0, NULL, NULL, NULL );
-    if (handler_id) g_signal_handler_block((gpointer)curveparam, handler_id);
+    if (handler_id) {
+        g_signal_handler_block((gpointer)curveparam, handler_id);
+    }
     gtk_combo_box_set_active (GTK_COMBO_BOX(curveparam),0);
-    if (handler_id) g_signal_handler_unblock((gpointer)curveparam, handler_id);
+    if (handler_id) {
+        g_signal_handler_unblock((gpointer)curveparam, handler_id);
+    }
+
     info->status_lock = osl;
 }
 
@@ -4182,9 +4187,6 @@ static void update_current_slot(int *history, int pm, int last_pm)
             gtk_spin_button_set_value( GTK_SPIN_BUTTON(widget_cache[WIDGET_SPIN_SAMPLESTART]), (gdouble) info->status_tokens[SAMPLE_START] );
             gtk_spin_button_set_value( GTK_SPIN_BUTTON(widget_cache[WIDGET_SPIN_SAMPLEEND]), (gdouble) info->status_tokens[SAMPLE_END]);
 
-            update_spin_range2( widget_cache[WIDGET_SAMPLE_TRANSITION_LENGTH], 1,
-                    info->status_tokens[SAMPLE_END], info->status_tokens[SAMPLE_TRANSITION_LENGTH] );
-
             timeline_set_length( info->tl,
                 (gdouble) info->status_tokens[SAMPLE_END], 
                 info->status_tokens[FRAME_NUM] );
@@ -4193,33 +4195,63 @@ static void update_current_slot(int *history, int pm, int last_pm)
          //   update_spin_range( "spin_text_end", 0, n_frames,n_frames );
 
         }
-
     }
 
-    if( pm == MODE_STREAM ) {
-        if( history[SAMPLE_TRANSITION_ACTIVE] != info->status_tokens[SAMPLE_TRANSITION_ACTIVE] ) {
-            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget_cache[WIDGET_STREAM_TRANSITION_ACTIVE]), info->status_tokens[SAMPLE_TRANSITION_ACTIVE]);
+    if (update){
+
+        //block "value-changed" signal to prevent propagation
+        guint signal_id = g_signal_lookup("value-changed", GTK_TYPE_SPIN_BUTTON);
+
+        gpointer widget_stl = (gpointer)widget_cache[WIDGET_SAMPLE_TRANSITION_LENGTH];
+        gpointer widget_sts = (gpointer)widget_cache[WIDGET_SAMPLE_TRANSITION_SHAPE];
+
+        gulong handler_stl = g_signal_handler_find( widget_stl,
+                                                    G_SIGNAL_MATCH_ID,
+                                                    signal_id,
+                                                    0, NULL, NULL, NULL );
+        gulong handler_sts = g_signal_handler_find( widget_sts,
+                                                    G_SIGNAL_MATCH_ID,
+                                                    signal_id,
+                                                    0, NULL, NULL, NULL );
+
+        if (handler_stl){
+            g_signal_handler_block(widget_stl, handler_stl);
         }
-        
-        if( history[SAMPLE_TRANSITION_LENGTH] != info->status_tokens[SAMPLE_TRANSITION_LENGTH]) {
-            gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_STREAM_TRANSITION_LENGTH]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_LENGTH]);
+        if (handler_sts){
+            g_signal_handler_block(widget_sts, handler_sts);
         }
 
-        if( history[SAMPLE_TRANSITION_SHAPE] != info->status_tokens[SAMPLE_TRANSITION_SHAPE]) {
-            gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_STREAM_TRANSITION_SHAPE]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_SHAPE]);
+        if( pm == MODE_STREAM ) {
+            if( history[SAMPLE_TRANSITION_ACTIVE] != info->status_tokens[SAMPLE_TRANSITION_ACTIVE] ) {
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget_cache[WIDGET_STREAM_TRANSITION_ACTIVE]), info->status_tokens[SAMPLE_TRANSITION_ACTIVE]);
+            }
+
+            update_spin_range2( widget_stl, (gdouble) info->status_tokens[SAMPLE_TRANSITION_LENGTH],
+                    info->status_tokens[SAMPLE_END], info->status_tokens[SAMPLE_TRANSITION_LENGTH] );
+
+            if( history[SAMPLE_TRANSITION_SHAPE] != info->status_tokens[SAMPLE_TRANSITION_SHAPE]) {
+                gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_STREAM_TRANSITION_SHAPE]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_SHAPE]);
+            }
         }
-    }
-    else if ( pm == MODE_SAMPLE ) {
-        if( history[SAMPLE_TRANSITION_ACTIVE] != info->status_tokens[SAMPLE_TRANSITION_ACTIVE] ) {
-            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_ACTIVE]), info->status_tokens[SAMPLE_TRANSITION_ACTIVE]);
-        }
-        
-        if( history[SAMPLE_TRANSITION_LENGTH] != info->status_tokens[SAMPLE_TRANSITION_LENGTH] ) {
-            gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_LENGTH]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_LENGTH]);
+        else if ( pm == MODE_SAMPLE ) {
+            if( history[SAMPLE_TRANSITION_ACTIVE] != info->status_tokens[SAMPLE_TRANSITION_ACTIVE] ) {
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_ACTIVE]), info->status_tokens[SAMPLE_TRANSITION_ACTIVE]);
+            }
+
+            if( history[SAMPLE_TRANSITION_LENGTH] != info->status_tokens[SAMPLE_TRANSITION_LENGTH] ) {
+                gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_LENGTH]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_LENGTH]);
+            }
+
+            if( history[SAMPLE_TRANSITION_SHAPE] != info->status_tokens[SAMPLE_TRANSITION_SHAPE] ) {
+                gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_SHAPE]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_SHAPE]);
+            }
         }
 
-        if( history[SAMPLE_TRANSITION_SHAPE] != info->status_tokens[SAMPLE_TRANSITION_SHAPE] ) {
-            gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget_cache[WIDGET_SAMPLE_TRANSITION_SHAPE]), (gdouble) info->status_tokens[SAMPLE_TRANSITION_SHAPE]);
+        if (handler_stl) {
+            g_signal_handler_unblock(widget_stl, handler_stl);
+        }
+        if (handler_sts) {
+            g_signal_handler_unblock(widget_sts, handler_sts);
         }
     }
 


### PR DESCRIPTION
* Prevent signal(s) propagation - Blocking "value-changed" when updating UI from server data.
* Use same callback for sample and stream
