### PR TITLE
transition: print transition status on vj_event_print_sample_info

### DIFF
--- a/veejay-current/veejay-server/veejay/liblavplayvj.c
+++ b/veejay-current/veejay-server/veejay/liblavplayvj.c
@@ -632,13 +632,13 @@ int	veejay_start_playing_sample( veejay_t *info, int sample_id )
 	    settings->previous_playback_speed = speed;
 
     veejay_set_speed(info, speed);
- 	 
+
 	veejay_msg(VEEJAY_MSG_INFO, "Playing sample %d (Sl=%d, Speed=%d, Start=%d, End=%d, Loop=%d, Cur=%ld) [transition to: %d pos %d - %d active %d - ready %d]",
 			sample_id, info->sfd, speed, start, end, looptype, (int) info->settings->current_frame_num,
-            settings->transition.next_id,
-            settings->transition.start,
-            settings->transition.end,
-            settings->transition.active,
+            settings->transition.next_id,    //FIXME
+            settings->transition.start,    //FIXME
+            settings->transition.end,    //FIXME
+            settings->transition.active,     //FIXME
             settings->transition.ready
             );
 	 

--- a/veejay-current/veejay-server/veejay/vj-event.c
+++ b/veejay-current/veejay-server/veejay/vj-event.c
@@ -7963,12 +7963,11 @@ void vj_event_print_sample_info(veejay_t *v, int id)
     }
     
     veejay_msg(VEEJAY_MSG_INFO, 
-        "[%09ld] - [%09ld] @ %4.2f [speed %d] [%s looping]",
+        "[%09ld]>[%09ld]@%4.2f [speed %d] [%s-loop] [transition%sactive (shape n°%02d>%d frames)]",
         start,end, (float)speed * v->current_edit_list->video_fps,speed,
-        (sample_get_looptype(id) ==
-        2 ? "pingpong" : (sample_get_looptype(id)==1 ? "normal" : (sample_get_looptype(id)==3 ? "random" : "none"))  )
+        (sample_get_looptype(id) == 2 ? "pingpong" : (sample_get_looptype(id)==1 ? "normal" : (sample_get_looptype(id)==3 ? "random" : "no"))),
+        (sample_get_transition_active(id) == 1 ? " " : " not " ), sample_get_transition_shape(id), sample_get_transition_length(id));
 
-        );
 
     for (i = 0; i < SAMPLE_MAX_EFFECTS; i++)
     {


### PR DESCRIPTION
(aka VIMS_PRINT_INFO / [HOME] )

Now the onliner info looklike :
`I: [000000000]>[000000250]@25.00 [speed 1] [normal-loop] [transition active (shape n°00>25 frames)]
`

NOTA: veejay_start_playing_sample need to be fixed, transition status
printed is not revelant